### PR TITLE
[chore/#6] QueryDSL 설정 및 Swagger 설정

### DIFF
--- a/clokey-api/build.gradle
+++ b/clokey-api/build.gradle
@@ -8,4 +8,8 @@ dependencies {
     implementation project(':clokey-common')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+
 }

--- a/clokey-api/src/main/java/org/clokey/ClokeyApiApplication.java
+++ b/clokey-api/src/main/java/org/clokey/ClokeyApiApplication.java
@@ -1,4 +1,4 @@
-package org.clokey.clokeyapi;
+package org.clokey;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/clokey-api/src/main/java/org/clokey/global/config/querydsl/QuerydslConfig.java
+++ b/clokey-api/src/main/java/org/clokey/global/config/querydsl/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package org.clokey.global.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/clokey-common-web/build.gradle
+++ b/clokey-common-web/build.gradle
@@ -10,4 +10,6 @@ dependencies {
     implementation project(':clokey-common')
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }

--- a/clokey-common-web/src/main/java/org/clokey/config/SwaggerConfig.java
+++ b/clokey-common-web/src/main/java/org/clokey/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package org.clokey.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI stewAPI() {
+        Info info = new Info().title("CLOKEY API").description("CLOKEY API 명세서").version("2.0.0");
+
+        String jwtSchemeName = "JWT TOKEN";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        Components components =
+                new Components()
+                        .addSecuritySchemes(
+                                jwtSchemeName,
+                                new SecurityScheme()
+                                        .name(jwtSchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/clokey-domain/build.gradle
+++ b/clokey-domain/build.gradle
@@ -8,4 +8,7 @@ jar {
 
 dependencies {
     implementation project(':clokey-common')
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #6 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- QueryDSL과 Swagger 설정을 했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
-  원래는 QueryDSL을 Domain 모듈에서 처리하고자 했으나, 나중에 Projection을 사용할 예정이어서 문제가 생겼습니다.
-  Projection을 사용하는 경우 관련 DTO가 API에 만들어지고, CustomRepository가 도메인에 존재할 경우 Domain 모듈이 API를 의존해 버리는 문제가 발생했습니다. 따라서, JPA Repository와 QueryDSL을 취급하는 Custom Repository를 모두 API 모듈에서 처리하기로 결정했습니다.
- 같은 이유로 QueryDSL Config도 api 모듈로 옮겼습니다 ( 이유는, 어짜피 config만 common-web에 놓더라도 프로젝션을 API 에서 구현해야 하니 공통 모듈로 뺴지 않도록 결정 - queryDSL 의존성을 또 주입해야함)
- Swagger의 경우에는 common-web 모듈에서 관리됩니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
