### PR TITLE
[feat/#8] Jpa Auditing Config 설정 및 BaseEntity 생성

### DIFF
--- a/clokey-api/build.gradle
+++ b/clokey-api/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
 
     implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
 

--- a/clokey-batch/build.gradle
+++ b/clokey-batch/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     implementation project(':clokey-common')
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     testImplementation 'org.springframework.batch:spring-batch-test'
+    runtimeOnly 'com.h2database:h2'
 }

--- a/clokey-domain/build.gradle
+++ b/clokey-domain/build.gradle
@@ -8,6 +8,8 @@ jar {
 
 dependencies {
     implementation project(':clokey-common')
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/clokey-domain/src/main/java/org/clokey/common/config/JpaAuditingConfig.java
+++ b/clokey-domain/src/main/java/org/clokey/common/config/JpaAuditingConfig.java
@@ -1,0 +1,8 @@
+package org.clokey.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {}

--- a/clokey-domain/src/main/java/org/clokey/common/model/BaseEntity.java
+++ b/clokey-domain/src/main/java/org/clokey/common/model/BaseEntity.java
@@ -1,0 +1,19 @@
+package org.clokey.common.model;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate private LocalDateTime createdAt;
+
+    @LastModifiedDate private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #8 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- Jpa Auditing Config 설정 및 BaseEntity 생성

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- BaseEntity는 기존에 사용하던 구조를 그대로 사용했습니다.
- Jpa Auditing Config를 별도로 분리한 이유는, @DataJpaTest 환경에서는 @SpringBootApplication 또는 @EnableJpaAuditing이 선언된 설정 클래스가 로드되지 않기 때문입니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
