### PR TITLE
[test/#14] 테스트 유틸리티 구현

### DIFF
--- a/clokey-api/src/main/java/org/clokey/util/TransactionUtil.java
+++ b/clokey-api/src/main/java/org/clokey/util/TransactionUtil.java
@@ -1,0 +1,14 @@
+package org.clokey.util;
+
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TransactionUtil {
+
+    @Transactional
+    public <T> T getResult(Supplier<T> transactionalTask) {
+        return transactionalTask.get();
+    }
+}

--- a/clokey-api/src/test/java/org/clokey/ClokeyApiApplicationTests.java
+++ b/clokey-api/src/test/java/org/clokey/ClokeyApiApplicationTests.java
@@ -1,10 +1,12 @@
-package org.clokey.clokeybatch;
+package org.clokey;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-class ClokeyBatchApplicationTests {
+@ActiveProfiles("test")
+class ClokeyApiApplicationTests {
 
     @Test
     void contextLoads() {}

--- a/clokey-api/src/test/java/org/clokey/DatabaseCleaner.java
+++ b/clokey-api/src/test/java/org/clokey/DatabaseCleaner.java
@@ -1,0 +1,62 @@
+package org.clokey;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import org.hibernate.Session;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseCleaner implements InitializingBean {
+
+    @PersistenceContext private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        entityManager.unwrap(Session.class).doWork(this::extractTableNames);
+    }
+
+    private void extractTableNames(Connection conn) {
+        tableNames =
+                entityManager.getMetamodel().getEntities().stream()
+                        .map(e -> e.getName().replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase())
+                        .toList();
+    }
+
+    public void execute() {
+        entityManager.unwrap(Session.class).doWork(this::cleanTables);
+    }
+
+    private void cleanTables(Connection conn) throws SQLException {
+        Statement statement = conn.createStatement();
+        statement.executeUpdate("SET REFERENTIAL_INTEGRITY FALSE");
+
+        for (String name : tableNames) {
+            statement.executeUpdate(String.format("TRUNCATE TABLE %s", name));
+            if (columnExists(conn, name, name)) {
+                statement.executeUpdate(
+                        String.format(
+                                "ALTER TABLE %s ALTER COLUMN %s_id RESTART WITH 1", name, name));
+            }
+        }
+
+        statement.executeUpdate("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+
+    private boolean columnExists(Connection conn, String tableName, String columnName)
+            throws SQLException {
+        try (ResultSet rs =
+                conn.getMetaData()
+                        .getColumns(
+                                null, null, tableName.toUpperCase(), columnName.toUpperCase())) {
+            return rs.next();
+        }
+    }
+}

--- a/clokey-api/src/test/java/org/clokey/IntegrationTest.java
+++ b/clokey-api/src/test/java/org/clokey/IntegrationTest.java
@@ -1,0 +1,18 @@
+package org.clokey;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public abstract class IntegrationTest {
+
+    @Autowired protected DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+    }
+}

--- a/clokey-api/src/test/java/org/clokey/RedisCleaner.java
+++ b/clokey-api/src/test/java/org/clokey/RedisCleaner.java
@@ -1,0 +1,18 @@
+package org.clokey;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisCleaner {
+
+    private final RedisConnectionFactory connectionFactory;
+
+    public RedisCleaner(RedisConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    public void flushAll() {
+        connectionFactory.getConnection().flushDb();
+    }
+}

--- a/clokey-batch/src/main/java/org/clokey/ClokeyBatchApplication.java
+++ b/clokey-batch/src/main/java/org/clokey/ClokeyBatchApplication.java
@@ -1,4 +1,4 @@
-package org.clokey.clokeybatch;
+package org.clokey;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/clokey-batch/src/test/java/org/clokey/ClokeyBatchApplicationTests.java
+++ b/clokey-batch/src/test/java/org/clokey/ClokeyBatchApplicationTests.java
@@ -1,12 +1,10 @@
-package org.clokey.clokeyapi;
+package org.clokey;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
-class ClokeyApiApplicationTests {
+class ClokeyBatchApplicationTests {
 
     @Test
     void contextLoads() {}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #14 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 테스트 환경에 필요한 유틸리티를 구현했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 --> 

### 🔴 Integration Test  & DB Cleaner
-  테스트 계획은 하나의 @Spring Boot (Integration Test)를 상속받아서 service와 repository의 통합 테스트를 구현할 계획입니다.
-  Transaction 롤백을 사용하지 않기 위해서 @DataJpaTest는 사용하지 않을 예정입니다.
-  그 이유는, Transaction 자체를 테스트에서도 검증하기 위함입니다.
-  따라서, DB Cleaner를 통해서 테스트간 독립적인 환경에서 진행되도록 DB를 비워줍니다.

### 🔴 TransactionUtil
- 테스트에서 별도의 트랜잭션을 걸어주지 않기 때문에 테스트 도중 LazyInitializationException이 발생할 수 있습니다.
- 그런 경우, TransactionUtil을 통해서 로딩 가능합니다.

### 🔴 Redis Cleaner
- Test에는 로컬 Redis가 사용됩니다. 테스트가 끝나고 Redis의 데이터를 지워주는 기능의 클래스입니다.
- Redis와 관련된 테스트는 제한적이기 때문에 Integration Test에서 항상 지워주지 않으므로, 필요한 경우 @AfterEach로 사용하시길 바랍니다.
