### PR TITLE
[feat/#19] 옷 생성 API 구현

### DIFF
--- a/clokey-api/build.gradle
+++ b/clokey-api/build.gradle
@@ -8,8 +8,6 @@ dependencies {
     implementation project(':clokey-common')
     implementation project(':clokey-infrastructure')
     implementation project(':clokey-common-web')
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/clokey-api/src/main/java/org/clokey/domain/category/exception/CategoryErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/category/exception/CategoryErrorCode.java
@@ -8,14 +8,15 @@ import org.clokey.exception.BaseErrorCode;
 @Getter
 @AllArgsConstructor
 public enum CategoryErrorCode implements BaseErrorCode {
-    CATEGORY_NOT_FOUND(404, "존재하지 않는 카테고리입니다."),
-    CATEGORY_IN_BULK_NOT_FOUND(404, "존재하지 않는 카테고리가 포함되어 있습니다.");
+    CATEGORY_NOT_FOUND(404, "CATEGORY_4041", "존재하지 않는 카테고리입니다."),
+    CATEGORY_IN_BULK_NOT_FOUND(404, "CATEGORY_4042", "존재하지 않는 카테고리가 포함되어 있습니다.");
 
     private int status;
+    private String code;
     private String message;
 
     @Override
     public ErrorReasonDto getErrorReason() {
-        return null;
+        return ErrorReasonDto.of(status, code, message);
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/category/exception/CategoryErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/category/exception/CategoryErrorCode.java
@@ -1,0 +1,21 @@
+package org.clokey.domain.category.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.clokey.dto.ErrorReasonDto;
+import org.clokey.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum CategoryErrorCode implements BaseErrorCode {
+    CATEGORY_NOT_FOUND(404, "존재하지 않는 카테고리입니다."),
+    CATEGORY_IN_BULK_NOT_FOUND(404, "존재하지 않는 카테고리가 포함되어 있습니다.");
+
+    private int status;
+    private String message;
+
+    @Override
+    public ErrorReasonDto getErrorReason() {
+        return null;
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/category/repository/CategoryRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/category/repository/CategoryRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    boolean existsByIdIn(Iterable<Long> ids);
+    long countByIdIn(Iterable<Long> ids);
 
     List<Category> findAllById(Iterable<Long> ids);
 }

--- a/clokey-api/src/main/java/org/clokey/domain/category/repository/CategoryRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/category/repository/CategoryRepository.java
@@ -1,6 +1,21 @@
 package org.clokey.domain.category.repository;
 
+import java.util.List;
 import org.clokey.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface CategoryRepository extends JpaRepository<Category, Long> {}
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query(
+            value =
+                    """
+            SELECT *
+            FROM category
+            WHERE id IN (:ids)
+            ORDER BY FIELD(id, :#{#ids})
+            """,
+            nativeQuery = true)
+    List<Category> findAllByIdInOrder(@Param("ids") List<Long> ids);
+}

--- a/clokey-api/src/main/java/org/clokey/domain/category/repository/CategoryRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/category/repository/CategoryRepository.java
@@ -3,19 +3,10 @@ package org.clokey.domain.category.repository;
 import java.util.List;
 import org.clokey.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    @Query(
-            value =
-                    """
-            SELECT *
-            FROM category
-            WHERE id IN (:ids)
-            ORDER BY FIELD(id, :#{#ids})
-            """,
-            nativeQuery = true)
-    List<Category> findAllByIdInOrder(@Param("ids") List<Long> ids);
+    boolean existsByIdIn(Iterable<Long> ids);
+
+    List<Category> findAllById(Iterable<Long> ids);
 }

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/controller/ClothController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/controller/ClothController.java
@@ -13,7 +13,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/cloths")
+@RequestMapping("/clothes")
 @RequiredArgsConstructor
 @Tag(name = "4. 옷 API", description = "옷 관련 API입니다.")
 @Validated

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/controller/ClothController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/controller/ClothController.java
@@ -1,0 +1,31 @@
+package org.clokey.domain.cloth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.clokey.code.GlobalBaseSuccessCode;
+import org.clokey.domain.cloth.dto.request.ClothCreateRequests;
+import org.clokey.domain.cloth.dto.response.ClothCreateResponse;
+import org.clokey.domain.cloth.service.ClothService;
+import org.clokey.response.BaseResponse;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/cloths")
+@RequiredArgsConstructor
+@Tag(name = "4. 옷 API", description = "옷 관련 API입니다.")
+@Validated
+public class ClothController {
+
+    private final ClothService clothService;
+
+    @PostMapping
+    @Operation(summary = "옷 생성", description = "새로운 옷을 생성합니다.")
+    public BaseResponse<ClothCreateResponse> createCloths(
+            @Valid @RequestBody ClothCreateRequests request) {
+        ClothCreateResponse response = clothService.createCloths(request);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.CREATED, response);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/dto/request/ClothCreateRequest.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/dto/request/ClothCreateRequest.java
@@ -1,0 +1,13 @@
+package org.clokey.domain.cloth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ClothCreateRequest(
+        @NotBlank(message = "옷의 이미지 주소는 비워둘 수 없습니다.")
+                @Schema(description = "옷의 이미지 주소", example = "https://example.jpg")
+                String clothImageUrl,
+        @NotNull(message = "옷의 카테고리 ID는 비워둘 수 없습니다.")
+                @Schema(description = "옷의 카테고리 ID", example = "1")
+                Long categoryId) {}

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/dto/request/ClothCreateRequests.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/dto/request/ClothCreateRequests.java
@@ -1,0 +1,7 @@
+package org.clokey.domain.cloth.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record ClothCreateRequests(
+        @NotEmpty(message = "적어도 하나의 옷을 생성해야 합니다.") List<ClothCreateRequest> content) {}

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/dto/request/ClothCreateRequests.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/dto/request/ClothCreateRequests.java
@@ -1,7 +1,8 @@
 package org.clokey.domain.cloth.dto.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
 public record ClothCreateRequests(
-        @NotEmpty(message = "적어도 하나의 옷을 생성해야 합니다.") List<ClothCreateRequest> content) {}
+        @NotEmpty(message = "적어도 하나의 옷을 생성해야 합니다.") @Valid List<ClothCreateRequest> content) {}

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/dto/response/ClothCreateResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/dto/response/ClothCreateResponse.java
@@ -1,0 +1,12 @@
+package org.clokey.domain.cloth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.clokey.cloth.entity.Cloth;
+
+public record ClothCreateResponse(
+        @Schema(description = "생성된 옷 ID들", example = "[1,2,3,4]") List<Long> clothIds) {
+    public static ClothCreateResponse from(List<Cloth> cloths) {
+        return new ClothCreateResponse(cloths.stream().map(Cloth::getId).toList());
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/service/ClothService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/service/ClothService.java
@@ -1,0 +1,9 @@
+package org.clokey.domain.cloth.service;
+
+import org.clokey.domain.cloth.dto.request.ClothCreateRequests;
+import org.clokey.domain.cloth.dto.response.ClothCreateResponse;
+
+public interface ClothService {
+
+    ClothCreateResponse createCloths(ClothCreateRequests list);
+}

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/service/ClothServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/service/ClothServiceImpl.java
@@ -56,7 +56,7 @@ public class ClothServiceImpl implements ClothService {
     }
 
     private Map<Long, Category> getCategoryMapByIds(Set<Long> ids) {
-        if (!categoryRepository.existsByIdIn(ids)) {
+        if (categoryRepository.countByIdIn(ids) != ids.size()) {
             throw new BaseCustomException(CategoryErrorCode.CATEGORY_IN_BULK_NOT_FOUND);
         }
 

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/service/ClothServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/service/ClothServiceImpl.java
@@ -1,0 +1,55 @@
+package org.clokey.domain.cloth.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.clokey.category.entity.Category;
+import org.clokey.cloth.entity.Cloth;
+import org.clokey.domain.category.repository.CategoryRepository;
+import org.clokey.domain.cloth.dto.request.ClothCreateRequest;
+import org.clokey.domain.cloth.dto.request.ClothCreateRequests;
+import org.clokey.domain.cloth.dto.response.ClothCreateResponse;
+import org.clokey.domain.cloth.repository.ClothRepository;
+import org.clokey.global.FakeAuthContext;
+import org.clokey.member.entity.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClothServiceImpl implements ClothService {
+
+    private final FakeAuthContext fakeAuthContext;
+
+    private final ClothRepository clothRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    @Transactional
+    public ClothCreateResponse createCloths(ClothCreateRequests request) {
+        final Member currentMember = fakeAuthContext.getCurrentMember();
+
+        List<Category> categories =
+                categoryRepository.findAllByIdInOrder(
+                        request.content().stream()
+                                .map(ClothCreateRequest::categoryId)
+                                .collect(Collectors.toList()));
+
+        List<Cloth> cloths =
+                IntStream.range(0, request.content().size())
+                        .mapToObj(
+                                i -> {
+                                    ClothCreateRequest cr = request.content().get(i);
+                                    Category category = categories.get(i);
+                                    return Cloth.createCloth(
+                                            cr.clothImageUrl(), category, currentMember);
+                                })
+                        .toList();
+
+        clothRepository.saveAll(cloths);
+
+        return ClothCreateResponse.from(cloths);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/service/ClothServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/service/ClothServiceImpl.java
@@ -1,16 +1,19 @@
 package org.clokey.domain.cloth.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.clokey.category.entity.Category;
 import org.clokey.cloth.entity.Cloth;
+import org.clokey.domain.category.exception.CategoryErrorCode;
 import org.clokey.domain.category.repository.CategoryRepository;
 import org.clokey.domain.cloth.dto.request.ClothCreateRequest;
 import org.clokey.domain.cloth.dto.request.ClothCreateRequests;
 import org.clokey.domain.cloth.dto.response.ClothCreateResponse;
 import org.clokey.domain.cloth.repository.ClothRepository;
+import org.clokey.exception.BaseCustomException;
 import org.clokey.global.FakeAuthContext;
 import org.clokey.member.entity.Member;
 import org.springframework.stereotype.Service;
@@ -31,18 +34,17 @@ public class ClothServiceImpl implements ClothService {
     public ClothCreateResponse createCloths(ClothCreateRequests request) {
         final Member currentMember = fakeAuthContext.getCurrentMember();
 
-        List<Category> categories =
-                categoryRepository.findAllByIdInOrder(
+        Map<Long, Category> categoryMap =
+                getCategoryMapByIds(
                         request.content().stream()
                                 .map(ClothCreateRequest::categoryId)
-                                .collect(Collectors.toList()));
+                                .collect(Collectors.toSet()));
 
         List<Cloth> cloths =
-                IntStream.range(0, request.content().size())
-                        .mapToObj(
-                                i -> {
-                                    ClothCreateRequest cr = request.content().get(i);
-                                    Category category = categories.get(i);
+                request.content().stream()
+                        .map(
+                                cr -> {
+                                    Category category = categoryMap.get(cr.categoryId());
                                     return Cloth.createCloth(
                                             cr.clothImageUrl(), category, currentMember);
                                 })
@@ -51,5 +53,14 @@ public class ClothServiceImpl implements ClothService {
         clothRepository.saveAll(cloths);
 
         return ClothCreateResponse.from(cloths);
+    }
+
+    private Map<Long, Category> getCategoryMapByIds(Set<Long> ids) {
+        if (!categoryRepository.existsByIdIn(ids)) {
+            throw new BaseCustomException(CategoryErrorCode.CATEGORY_IN_BULK_NOT_FOUND);
+        }
+
+        return categoryRepository.findAllById(ids).stream()
+                .collect(Collectors.toMap(Category::getId, c -> c));
     }
 }

--- a/clokey-api/src/main/java/org/clokey/global/FakeAuthContext.java
+++ b/clokey-api/src/main/java/org/clokey/global/FakeAuthContext.java
@@ -21,6 +21,7 @@ public class FakeAuthContext {
                 Member.createMember(
                         "tempEmail",
                         "tempClokeyId",
+                        "tempNickname",
                         OauthInfo.createOauthInfo("tempOid", OauthProvider.KAKAO),
                         MemberStatus.ACTIVE,
                         RegisterStatus.REGISTERED,

--- a/clokey-api/src/main/java/org/clokey/global/FakeAuthContext.java
+++ b/clokey-api/src/main/java/org/clokey/global/FakeAuthContext.java
@@ -1,0 +1,32 @@
+package org.clokey.global;
+
+import lombok.RequiredArgsConstructor;
+import org.clokey.domain.member.repository.MemberRepository;
+import org.clokey.member.entity.Member;
+import org.clokey.member.entity.OauthInfo;
+import org.clokey.member.enums.MemberStatus;
+import org.clokey.member.enums.OauthProvider;
+import org.clokey.member.enums.RegisterStatus;
+import org.clokey.member.enums.Visibility;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FakeAuthContext {
+
+    private final MemberRepository memberRepository;
+
+    public Member getCurrentMember() {
+        Member member =
+                Member.createMember(
+                        "tempEmail",
+                        "tempClokeyId",
+                        OauthInfo.createOauthInfo("tempOid", OauthProvider.KAKAO),
+                        MemberStatus.ACTIVE,
+                        RegisterStatus.REGISTERED,
+                        Visibility.PUBLIC);
+
+        memberRepository.save(member);
+        return member;
+    }
+}

--- a/clokey-api/src/test/java/org/clokey/domain/cloth/controller/ClothControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/cloth/controller/ClothControllerTest.java
@@ -8,10 +8,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import org.clokey.domain.category.exception.CategoryErrorCode;
 import org.clokey.domain.cloth.dto.request.ClothCreateRequest;
 import org.clokey.domain.cloth.dto.request.ClothCreateRequests;
 import org.clokey.domain.cloth.dto.response.ClothCreateResponse;
 import org.clokey.domain.cloth.service.ClothService;
+import org.clokey.exception.BaseCustomException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -54,7 +56,7 @@ class ClothControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/cloths")
+                            post("/clothes")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -74,7 +76,7 @@ class ClothControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/cloths")
+                            post("/clothes")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -97,7 +99,7 @@ class ClothControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/cloths")
+                            post("/clothes")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -118,7 +120,7 @@ class ClothControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/cloths")
+                            post("/clothes")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -127,6 +129,29 @@ class ClothControllerTest {
                     .andExpect(jsonPath("$.code").value("COMMON400"))
                     .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
                     .andExpect(jsonPath("$.result.categoryId").value("옷의 카테고리 ID는 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 카테고리가_존재하지_않을_경우_예외가_발생한다() throws Exception {
+            // given
+            ClothCreateRequests request =
+                    new ClothCreateRequests(
+                            List.of(new ClothCreateRequest("testClothImageUrl1", 999L)));
+            given(clothService.createCloths(request))
+                    .willThrow(
+                            new BaseCustomException(CategoryErrorCode.CATEGORY_IN_BULK_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/clothes")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("CATEGORY_4042"))
+                    .andExpect(jsonPath("$.message").value("존재하지 않는 카테고리가 포함되어 있습니다."));
         }
     }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/cloth/controller/ClothControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/cloth/controller/ClothControllerTest.java
@@ -1,0 +1,85 @@
+package org.clokey.domain.cloth.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.clokey.domain.cloth.dto.request.ClothCreateRequest;
+import org.clokey.domain.cloth.dto.request.ClothCreateRequests;
+import org.clokey.domain.cloth.dto.response.ClothCreateResponse;
+import org.clokey.domain.cloth.service.ClothService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(ClothController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ClothControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private ClothService clothService;
+
+    @Nested
+    class 옷_생성_요청_시 {
+
+        @Test
+        void 유효한_요청이면_생성된_옷_ID를_반환한다() throws Exception {
+            // given
+            ClothCreateRequests request =
+                    new ClothCreateRequests(
+                            List.of(
+                                    new ClothCreateRequest("testClothImageUrl1", 1L),
+                                    new ClothCreateRequest("testClothImageUrl2", 1L)));
+
+            ClothCreateResponse response = new ClothCreateResponse(List.of(1L, 2L));
+
+            given(clothService.createCloths(request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/cloths")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON201"))
+                    .andExpect(jsonPath("$.message").value("요청 성공 및 리소스 생성됨"))
+                    .andExpect(jsonPath("$.result.clothIds[0]").value(1))
+                    .andExpect(jsonPath("$.result.clothIds[1]").value(2));
+        }
+
+        @Test
+        void 빈_요청이면_예외를_반환한다() throws Exception {
+            // given
+            ClothCreateRequests request = new ClothCreateRequests(List.of());
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/cloths")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON201"))
+                    .andExpect(jsonPath("$.message").value("요청 성공 및 리소스 생성됨"))
+                    .andExpect(jsonPath("$.result.clothIds[0]").value(1))
+                    .andExpect(jsonPath("$.result.clothIds[1]").value(2));
+        }
+    }
+}

--- a/clokey-api/src/test/java/org/clokey/domain/cloth/controller/ClothControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/cloth/controller/ClothControllerTest.java
@@ -14,6 +14,10 @@ import org.clokey.domain.cloth.dto.response.ClothCreateResponse;
 import org.clokey.domain.cloth.service.ClothService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -63,7 +67,7 @@ class ClothControllerTest {
         }
 
         @Test
-        void 빈_요청이면_예외를_반환한다() throws Exception {
+        void 빈_요청이면_예외가_발생한다() throws Exception {
             // given
             ClothCreateRequests request = new ClothCreateRequests(List.of());
 
@@ -76,10 +80,53 @@ class ClothControllerTest {
 
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.isSuccess").value(false))
-                    .andExpect(jsonPath("$.code").value("COMMON201"))
-                    .andExpect(jsonPath("$.message").value("요청 성공 및 리소스 생성됨"))
-                    .andExpect(jsonPath("$.result.clothIds[0]").value(1))
-                    .andExpect(jsonPath("$.result.clothIds[1]").value(2));
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.content").value("적어도 하나의 옷을 생성해야 합니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void 옷의_이미지_url이_null_또는_공백이면_예외가_발생한다(String clothImageUrl) throws Exception {
+            // given
+            ClothCreateRequests request =
+                    new ClothCreateRequests(List.of(new ClothCreateRequest(clothImageUrl, 1L)));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/cloths")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.clothImageUrl").value("옷의 이미지 주소는 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 옷의_카테고리_ID를_비워두면_예외가_발생한다() throws Exception {
+            // given
+            ClothCreateRequests request =
+                    new ClothCreateRequests(
+                            List.of(new ClothCreateRequest("testClothImageUrl", null)));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/cloths")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.categoryId").value("옷의 카테고리 ID는 비워둘 수 없습니다."));
         }
     }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/cloth/service/ClothServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/cloth/service/ClothServiceTest.java
@@ -1,0 +1,84 @@
+package org.clokey.domain.cloth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import org.clokey.IntegrationTest;
+import org.clokey.category.entity.Category;
+import org.clokey.domain.category.repository.CategoryRepository;
+import org.clokey.domain.cloth.dto.request.ClothCreateRequest;
+import org.clokey.domain.cloth.dto.request.ClothCreateRequests;
+import org.clokey.domain.cloth.repository.ClothRepository;
+import org.clokey.domain.member.repository.MemberRepository;
+import org.clokey.global.FakeAuthContext;
+import org.clokey.member.entity.Member;
+import org.clokey.member.entity.OauthInfo;
+import org.clokey.member.enums.MemberStatus;
+import org.clokey.member.enums.OauthProvider;
+import org.clokey.member.enums.RegisterStatus;
+import org.clokey.member.enums.Visibility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class ClothServiceTest extends IntegrationTest {
+
+    @Autowired private ClothService clothService;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private ClothRepository clothRepository;
+    @Autowired private CategoryRepository categoryRepository;
+
+    @MockitoBean FakeAuthContext fakeAuthContext;
+
+    @Nested
+    class 옷을_생성할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            "testEmail",
+                            "testClokeyId",
+                            "testNickName",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO),
+                            MemberStatus.ACTIVE,
+                            RegisterStatus.REGISTERED,
+                            Visibility.PUBLIC);
+
+            memberRepository.save(member);
+            given(fakeAuthContext.getCurrentMember()).willReturn(member);
+
+            Category category = Category.createCategory("testCategory", null);
+            categoryRepository.save(category);
+        }
+
+        @Test
+        void 유효한_요청이면_옷을_생성한다() {
+            // given
+            ClothCreateRequests request =
+                    new ClothCreateRequests(
+                            List.of(
+                                    new ClothCreateRequest("testClothImageUrl1", 1L),
+                                    new ClothCreateRequest("testClothImageUrl2", 1L)));
+
+            // when
+            clothService.createCloths(request);
+
+            // then
+            Assertions.assertAll(
+                    () ->
+                            assertThat(clothRepository.findById(1L).orElseThrow())
+                                    .extracting("id", "clothImageUrl", "category.id", "member.id")
+                                    .containsExactly(1L, "testClothImageUrl1", 1L, 1L),
+                    () ->
+                            assertThat(clothRepository.findById(2L).orElseThrow())
+                                    .extracting("id", "clothImageUrl", "category.id", "member.id")
+                                    .containsExactly(1L, "testClothImageUrl2", 1L, 1L));
+        }
+    }
+}

--- a/clokey-api/src/test/java/org/clokey/domain/cloth/service/ClothServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/cloth/service/ClothServiceTest.java
@@ -76,7 +76,7 @@ class ClothServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () ->
                             assertThat(clothRepository.findById(1L).orElseThrow())
-                                    .extracting("lothImageUrl", "category.id", "member.id")
+                                    .extracting("clothImageUrl", "category.id", "member.id")
                                     .containsExactly("testClothImageUrl1", 1L, 1L),
                     () ->
                             assertThat(clothRepository.findById(2L).orElseThrow())

--- a/clokey-api/src/test/java/org/clokey/domain/cloth/service/ClothServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/cloth/service/ClothServiceTest.java
@@ -1,17 +1,20 @@
 package org.clokey.domain.cloth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
 import java.util.List;
 import org.clokey.IntegrationTest;
 import org.clokey.category.entity.Category;
+import org.clokey.domain.category.exception.CategoryErrorCode;
 import org.clokey.domain.category.repository.CategoryRepository;
 import org.clokey.domain.cloth.dto.request.ClothCreateRequest;
 import org.clokey.domain.cloth.dto.request.ClothCreateRequests;
 import org.clokey.domain.cloth.repository.ClothRepository;
 import org.clokey.domain.member.repository.MemberRepository;
+import org.clokey.exception.BaseCustomException;
 import org.clokey.global.FakeAuthContext;
 import org.clokey.member.entity.Member;
 import org.clokey.member.entity.OauthInfo;
@@ -73,12 +76,27 @@ class ClothServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () ->
                             assertThat(clothRepository.findById(1L).orElseThrow())
-                                    .extracting("id", "clothImageUrl", "category.id", "member.id")
-                                    .containsExactly(1L, "testClothImageUrl1", 1L, 1L),
+                                    .extracting("lothImageUrl", "category.id", "member.id")
+                                    .containsExactly("testClothImageUrl1", 1L, 1L),
                     () ->
                             assertThat(clothRepository.findById(2L).orElseThrow())
-                                    .extracting("id", "clothImageUrl", "category.id", "member.id")
-                                    .containsExactly(1L, "testClothImageUrl2", 1L, 1L));
+                                    .extracting("clothImageUrl", "category.id", "member.id")
+                                    .containsExactly("testClothImageUrl2", 1L, 1L));
+        }
+
+        @Test
+        void 카테고리가_존재하지_않을_경우_예외가_발생한다() {
+            // given
+            ClothCreateRequests request =
+                    new ClothCreateRequests(
+                            List.of(
+                                    new ClothCreateRequest("testClothImageUrl1", 1L),
+                                    new ClothCreateRequest("testClothImageUrl2", 999L)));
+
+            // when & then
+            assertThatThrownBy(() -> clothService.createCloths(request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(CategoryErrorCode.CATEGORY_IN_BULK_NOT_FOUND.getMessage());
         }
     }
 }

--- a/clokey-common-web/build.gradle
+++ b/clokey-common-web/build.gradle
@@ -8,8 +8,8 @@ jar {
 
 dependencies {
     implementation project(':clokey-common')
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-validation")
+    api("org.springframework.boot:spring-boot-starter-web")
+    api("org.springframework.boot:spring-boot-starter-validation")
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }

--- a/clokey-common-web/src/main/java/org/clokey/exception/GlobalExceptionAdvice.java
+++ b/clokey-common-web/src/main/java/org/clokey/exception/GlobalExceptionAdvice.java
@@ -4,7 +4,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.clokey.response.BaseResponse;
 import org.springframework.beans.TypeMismatchException;
@@ -32,7 +31,6 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
             HttpStatusCode status,
             WebRequest request) {
         String errorMessage = e.getPropertyName() + ": 올바른 값이 아닙니다.";
-
         return handleExceptionInternalMessage(e, headers, request, errorMessage);
     }
 
@@ -43,7 +41,6 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
             HttpStatusCode status,
             WebRequest request) {
         String errorMessage = e.getParameterName() + ": 올바른 값이 아닙니다.";
-
         return handleExceptionInternalMessage(e, headers, request, errorMessage);
     }
 
@@ -53,13 +50,13 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
                 e.getConstraintViolations().stream()
                         .map(constraintViolation -> constraintViolation.getMessage())
                         .findFirst()
-                        .orElseThrow(
-                                () ->
-                                        new RuntimeException(
-                                                "ConstraintViolationException 추출 도중 에러 발생"));
+                        .orElse("COMMON400");
 
-        return handleExceptionInternalConstraint(
-                e, GlobalBaseErrorCode.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+        GlobalBaseErrorCode errorCode =
+                GlobalBaseErrorCode.findByCode(errorMessage)
+                        .orElse(GlobalBaseErrorCode.BAD_REQUEST);
+
+        return handleExceptionInternalConstraint(e, errorCode, HttpHeaders.EMPTY, request);
     }
 
     @Override
@@ -77,73 +74,49 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
                 .forEach(
                         fieldError -> {
                             String fieldName = fieldError.getField();
-                            String errorMessage;
-                            try {
-                                errorMessage =
-                                        Optional.ofNullable(
-                                                        GlobalBaseErrorCode.valueOf(
-                                                                        fieldError
-                                                                                .getDefaultMessage())
-                                                                .getMessage())
-                                                .orElse("");
-                            } catch (IllegalArgumentException ex) {
-                                errorMessage =
-                                        Optional.ofNullable(fieldError.getDefaultMessage())
-                                                .orElse("");
-                            }
+                            String errorMessage =
+                                    GlobalBaseErrorCode.findByCode(fieldError.getDefaultMessage())
+                                            .map(GlobalBaseErrorCode::getMessage)
+                                            .orElse(fieldError.getDefaultMessage());
                             errors.merge(
                                     fieldName,
                                     errorMessage,
-                                    (existingErrorMessage, newErrorMessage) ->
-                                            existingErrorMessage + ", " + newErrorMessage);
+                                    (existing, replacement) -> existing + ", " + replacement);
                         });
 
-        // 클래스 레벨 에러 처리 (ObjectError)
+        // 클래스 레벨 에러 처리
         e.getBindingResult()
                 .getGlobalErrors()
                 .forEach(
                         objectError -> {
-                            String objectName = objectError.getObjectName();
-                            String errorMessage;
-                            try {
-                                errorMessage =
-                                        Optional.ofNullable(
-                                                        GlobalBaseErrorCode.valueOf(
-                                                                        objectError
-                                                                                .getDefaultMessage())
-                                                                .getMessage())
-                                                .orElse("");
-                            } catch (IllegalArgumentException ex) {
-                                errorMessage =
-                                        Optional.ofNullable(objectError.getDefaultMessage())
-                                                .orElse("");
-                            }
+                            String errorMessage =
+                                    GlobalBaseErrorCode.findByCode(objectError.getDefaultMessage())
+                                            .map(GlobalBaseErrorCode::getMessage)
+                                            .orElse(objectError.getDefaultMessage());
                             errors.merge(
                                     "message :",
                                     errorMessage,
-                                    (existingErrorMessage, newErrorMessage) ->
-                                            existingErrorMessage + ", " + newErrorMessage);
+                                    (existing, replacement) -> existing + ", " + replacement);
                         });
 
         return handleExceptionInternalArgs(
-                e, HttpHeaders.EMPTY, GlobalBaseErrorCode.valueOf("BAD_REQUEST"), request, errors);
+                e, HttpHeaders.EMPTY, GlobalBaseErrorCode.BAD_REQUEST, request, errors);
     }
 
     @ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
         e.printStackTrace();
-
         return handleExceptionInternalFalse(
                 e,
                 GlobalBaseErrorCode.INTERNAL_SERVER_ERROR,
                 HttpHeaders.EMPTY,
-                HttpStatus.valueOf(GlobalBaseErrorCode.INTERNAL_SERVER_ERROR.getCode()),
+                HttpStatus.valueOf(GlobalBaseErrorCode.INTERNAL_SERVER_ERROR.getStatus()),
                 request,
                 e.getMessage());
     }
 
-    @ExceptionHandler(value = BaseCustomException.class)
-    public ResponseEntity onThrowException(
+    @ExceptionHandler(BaseCustomException.class)
+    public ResponseEntity<Object> onThrowException(
             BaseCustomException baseCustomException, HttpServletRequest request) {
         return handleExceptionInternal(
                 baseCustomException, baseCustomException.getCode(), null, request);
@@ -153,8 +126,8 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
             Exception e, BaseErrorCode code, HttpHeaders headers, HttpServletRequest request) {
 
         BaseResponse<Object> body = BaseResponse.onFailure(code, null);
-
         WebRequest webRequest = new ServletWebRequest(request);
+
         return super.handleExceptionInternal(
                 e, body, headers, HttpStatus.valueOf(code.getErrorReason().status()), webRequest);
     }
@@ -166,6 +139,7 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
             HttpStatus status,
             WebRequest request,
             String errorPoint) {
+
         BaseResponse<Object> body = BaseResponse.onFailure(errorCommonStatus, errorPoint);
         return super.handleExceptionInternal(e, body, headers, status, request);
     }
@@ -176,9 +150,10 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
             GlobalBaseErrorCode errorCommonStatus,
             WebRequest request,
             Map<String, String> errorArgs) {
+
         BaseResponse<Object> body = BaseResponse.onFailure(errorCommonStatus, errorArgs);
         return super.handleExceptionInternal(
-                e, body, headers, HttpStatus.valueOf(errorCommonStatus.getCode()), request);
+                e, body, headers, HttpStatus.valueOf(errorCommonStatus.getStatus()), request);
     }
 
     private ResponseEntity<Object> handleExceptionInternalConstraint(
@@ -186,6 +161,7 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
             GlobalBaseErrorCode errorCommonStatus,
             HttpHeaders headers,
             WebRequest request) {
+
         BaseResponse<Object> body = BaseResponse.onFailure(errorCommonStatus, null);
         return super.handleExceptionInternal(
                 e, body, headers, HttpStatus.valueOf(errorCommonStatus.getStatus()), request);
@@ -193,10 +169,11 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
 
     private ResponseEntity<Object> handleExceptionInternalMessage(
             Exception e, HttpHeaders headers, WebRequest request, String errorMessage) {
+
         GlobalBaseErrorCode errorStatus = GlobalBaseErrorCode.BAD_REQUEST;
         BaseResponse<String> body = BaseResponse.onFailure(errorStatus, errorMessage);
 
         return super.handleExceptionInternal(
-                e, body, headers, HttpStatus.valueOf(errorStatus.getCode()), request);
+                e, body, headers, HttpStatus.valueOf(errorStatus.getStatus()), request);
     }
 }

--- a/clokey-common-web/src/main/java/org/clokey/exception/GlobalExceptionAdvice.java
+++ b/clokey-common-web/src/main/java/org/clokey/exception/GlobalExceptionAdvice.java
@@ -73,13 +73,20 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
                 .getFieldErrors()
                 .forEach(
                         fieldError -> {
-                            String fieldName = fieldError.getField();
+                            String rawFieldName =
+                                    fieldError.getField(); // ex: content[0].clothImageUrl
+                            String simplifiedFieldName =
+                                    rawFieldName
+                                            .substring(rawFieldName.lastIndexOf('.') + 1)
+                                            .replaceAll(".*\\.", ""); // → clothImageUrl
+
                             String errorMessage =
                                     GlobalBaseErrorCode.findByCode(fieldError.getDefaultMessage())
                                             .map(GlobalBaseErrorCode::getMessage)
                                             .orElse(fieldError.getDefaultMessage());
+
                             errors.merge(
-                                    fieldName,
+                                    simplifiedFieldName,
                                     errorMessage,
                                     (existing, replacement) -> existing + ", " + replacement);
                         });
@@ -93,14 +100,15 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
                                     GlobalBaseErrorCode.findByCode(objectError.getDefaultMessage())
                                             .map(GlobalBaseErrorCode::getMessage)
                                             .orElse(objectError.getDefaultMessage());
+
                             errors.merge(
-                                    "message :",
+                                    "message",
                                     errorMessage,
                                     (existing, replacement) -> existing + ", " + replacement);
                         });
 
         return handleExceptionInternalArgs(
-                e, HttpHeaders.EMPTY, GlobalBaseErrorCode.BAD_REQUEST, request, errors);
+                e, headers, GlobalBaseErrorCode.BAD_REQUEST, request, errors);
     }
 
     @ExceptionHandler

--- a/clokey-common/src/main/java/org/clokey/exception/BaseCustomException.java
+++ b/clokey-common/src/main/java/org/clokey/exception/BaseCustomException.java
@@ -1,14 +1,17 @@
 package org.clokey.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.clokey.dto.ErrorReasonDto;
 
 @Getter
-@AllArgsConstructor
 public class BaseCustomException extends RuntimeException {
 
-    private BaseErrorCode code;
+    private final BaseErrorCode code;
+
+    public BaseCustomException(BaseErrorCode code) {
+        super(code.getErrorReason().message());
+        this.code = code;
+    }
 
     public ErrorReasonDto getErrorReasonDto() {
         return this.code.getErrorReason();

--- a/clokey-common/src/main/java/org/clokey/exception/GlobalBaseErrorCode.java
+++ b/clokey-common/src/main/java/org/clokey/exception/GlobalBaseErrorCode.java
@@ -1,5 +1,7 @@
 package org.clokey.exception;
 
+import java.util.Arrays;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.clokey.dto.ErrorReasonDto;
@@ -21,5 +23,9 @@ public enum GlobalBaseErrorCode implements BaseErrorCode {
     @Override
     public ErrorReasonDto getErrorReason() {
         return ErrorReasonDto.of(status, code, message);
+    }
+
+    public static Optional<GlobalBaseErrorCode> findByCode(String code) {
+        return Arrays.stream(values()).filter(e -> e.getCode().equals(code)).findFirst();
     }
 }

--- a/clokey-domain/src/main/java/org/clokey/category/entity/Category.java
+++ b/clokey-domain/src/main/java/org/clokey/category/entity/Category.java
@@ -22,6 +22,13 @@ public class Category extends BaseEntity {
     @JoinColumn(name = "parent_id")
     private Category parent;
 
-    //    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<Category> children = new ArrayList<>();
+    @Builder(access = AccessLevel.PRIVATE)
+    private Category(String name, Category parent) {
+        this.name = name;
+        this.parent = parent;
+    }
+
+    public static Category createCategory(String name, Category parent) {
+        return Category.builder().name(name).parent(parent).build();
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/cloth/entity/Cloth.java
+++ b/clokey-domain/src/main/java/org/clokey/cloth/entity/Cloth.java
@@ -37,6 +37,21 @@ public class Cloth extends BaseEntity {
     @NotNull
     private Member member;
 
+    @Builder(access = AccessLevel.PRIVATE)
+    private Cloth(String clothImageUrl, Category category, Member member) {
+        this.clothImageUrl = clothImageUrl;
+        this.category = category;
+        this.member = member;
+    }
+
+    public static Cloth createCloth(String clothImageUrl, Category category, Member member) {
+        return Cloth.builder()
+                .clothImageUrl(clothImageUrl)
+                .category(category)
+                .member(member)
+                .build();
+    }
+
     //    @OneToMany(mappedBy = "cloth", cascade = CascadeType.ALL, orphanRemoval = true)
     //    private List<HistoryCloth> historyCloths = new ArrayList<>();
     //

--- a/clokey-domain/src/main/java/org/clokey/member/entity/Member.java
+++ b/clokey-domain/src/main/java/org/clokey/member/entity/Member.java
@@ -56,12 +56,14 @@ public class Member extends BaseEntity {
     private Member(
             String email,
             String clokeyId,
+            String nickname,
             OauthInfo oauthInfo,
             MemberStatus memberStatus,
             RegisterStatus registerStatus,
             Visibility visibility) {
         this.email = email;
         this.clokeyId = clokeyId;
+        this.nickname = nickname;
         this.oauthInfo = oauthInfo;
         this.memberStatus = memberStatus;
         this.registerStatus = registerStatus;
@@ -71,6 +73,7 @@ public class Member extends BaseEntity {
     public static Member createMember(
             String email,
             String clokeyId,
+            String nickname,
             OauthInfo oauthInfo,
             MemberStatus memberStatus,
             RegisterStatus registerStatus,
@@ -78,6 +81,7 @@ public class Member extends BaseEntity {
         return Member.builder()
                 .email(email)
                 .clokeyId(clokeyId)
+                .nickname(nickname)
                 .oauthInfo(oauthInfo)
                 .memberStatus(memberStatus)
                 .registerStatus(registerStatus)

--- a/clokey-domain/src/main/java/org/clokey/member/entity/Member.java
+++ b/clokey-domain/src/main/java/org/clokey/member/entity/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.clokey.common.model.BaseEntity;
@@ -23,9 +24,11 @@ public class Member extends BaseEntity {
     @NotNull private String email;
 
     @Column(unique = true)
+    @NotNull
     private String clokeyId;
 
     @Column(length = 30)
+    @NotNull
     private String nickname;
 
     @Embedded private OauthInfo oauthInfo;
@@ -48,6 +51,39 @@ public class Member extends BaseEntity {
     private String deviceToken;
 
     private LocalDate inactiveDate;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Member(
+            String email,
+            String clokeyId,
+            OauthInfo oauthInfo,
+            MemberStatus memberStatus,
+            RegisterStatus registerStatus,
+            Visibility visibility) {
+        this.email = email;
+        this.clokeyId = clokeyId;
+        this.oauthInfo = oauthInfo;
+        this.memberStatus = memberStatus;
+        this.registerStatus = registerStatus;
+        this.visibility = visibility;
+    }
+
+    public static Member createMember(
+            String email,
+            String clokeyId,
+            OauthInfo oauthInfo,
+            MemberStatus memberStatus,
+            RegisterStatus registerStatus,
+            Visibility visibility) {
+        return Member.builder()
+                .email(email)
+                .clokeyId(clokeyId)
+                .oauthInfo(oauthInfo)
+                .memberStatus(memberStatus)
+                .registerStatus(registerStatus)
+                .visibility(visibility)
+                .build();
+    }
     //
     //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     //    private List<MemberTerm> memberTermList = new ArrayList<>();

--- a/clokey-domain/src/main/java/org/clokey/member/entity/OauthInfo.java
+++ b/clokey-domain/src/main/java/org/clokey/member/entity/OauthInfo.java
@@ -4,9 +4,10 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.clokey.member.enums.SocialType;
+import org.clokey.member.enums.OauthProvider;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,5 +17,15 @@ public class OauthInfo {
 
     @Enumerated(EnumType.STRING)
     @NotNull
-    private SocialType socialType;
+    private OauthProvider oauthProvider;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private OauthInfo(String oauthId, OauthProvider oauthProvider) {
+        this.oauthId = oauthId;
+        this.oauthProvider = oauthProvider;
+    }
+
+    public static OauthInfo createOauthInfo(String oauthId, OauthProvider oauthProvider) {
+        return OauthInfo.builder().oauthId(oauthId).oauthProvider(oauthProvider).build();
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/member/enums/OauthProvider.java
+++ b/clokey-domain/src/main/java/org/clokey/member/enums/OauthProvider.java
@@ -1,6 +1,6 @@
 package org.clokey.member.enums;
 
-public enum SocialType {
+public enum OauthProvider {
     KAKAO,
     APPLE
 }

--- a/clokey-domain/src/main/resources/db/migration/V1__init.sql
+++ b/clokey-domain/src/main/resources/db/migration/V1__init.sql
@@ -5,8 +5,8 @@ CREATE TABLE member (
                         nickname VARCHAR(30) NOT NULL,
                         oauth_id VARCHAR(255) NOT NULL ,
 
-                        social_type VARCHAR(255) NOT NULL CHECK (
-                            social_type IN ('KAKAO', 'APPLE')
+                        oauth_provider VARCHAR(255) NOT NULL CHECK (
+                            oauth_provider IN ('KAKAO', 'APPLE')
                             ),
 
                         member_status VARCHAR(255) NOT NULL DEFAULT 'ACTIVE' CHECK (

--- a/clokey-domain/src/main/resources/db/migration/V1__init.sql
+++ b/clokey-domain/src/main/resources/db/migration/V1__init.sql
@@ -1,8 +1,8 @@
 CREATE TABLE member (
                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
                         email VARCHAR(255) NOT NULL,
-                        clokey_id VARCHAR(255) UNIQUE,
-                        nickname VARCHAR(30),
+                        clokey_id VARCHAR(255) UNIQUE NOT NULL ,
+                        nickname VARCHAR(30) NOT NULL,
                         oauth_id VARCHAR(255) NOT NULL ,
 
                         social_type VARCHAR(255) NOT NULL CHECK (


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #19 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 옷 생성 API를 구현했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 옷 생성 API 로직을 구현했습니다.
- 로직적인 부분과 테스트 케이스에 오류가 없는지 확인 부탁드려요

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
- 다음과 같이 response와 request는 record를 사용해 주세요.

도메인마다 기존에는 도메인 Exception을 만들었는데요 그럴 필요가 있나 생각했습니다. 
도메인 마다 다른 에러가 터질수도 있는데.. 
ex) 옷을 생성하는 중에 category가 없다면..  ClothException(ClothErrorCode) 이 구조가 이상해지는 것 같아서 그냥 BaseException 사용했습니다.

이제 Swagger를 사용한 테스트가 아닌 테스트 코드를 통해서 검증해주시면 됩니다.
간단히 구조를 설명드리면.

## Controller Test (응답 반환 테스트)
<img width="351" height="132" alt="스크린샷 2025-08-08 오후 3 21 39" src="https://github.com/user-attachments/assets/31a606ed-b986-4dd1-b231-54f4d7fcc14c" />

- 하나의 API에 상황이 분기가 많이 되는 과정이 없다면 하나의 Nested로 처리 부탁드립니다.
- 제목은 요청 검증이니 "~ 요청_시" 로 통일하겠습니다. -> 성공시 :  ~반환한다   실패시 : ~ 예외가 발생한다
- 응답값을 검증합니다, 여기서 DTO 검증이 잘 되는지 검사할 수 있어요.
- Service 내의 에러가 어떻게 반환되는지도 추가를 해야하는데 나중에 추가하겠습니다. (지금 PR 예시에서는 카테고리가 없는 경우 응답도 검증해야함)
- 따라서, Controller Test는 요청값 검증과 서비스 로직 에러가 잘 반환되는지 검사합니다.

## Service Test (통합 테스트)

<img width="195" height="79" alt="스크린샷 2025-08-08 오후 3 26 06" src="https://github.com/user-attachments/assets/f278a610-688e-4353-80ac-d1423a76e22e" />

- Nested 명명은 "~할_때" 로 통일하고 성공시 : ~ 한다 실패시: ~예외가 발생한다 로 부탁드립니다.
- 로직 자체를 검증합니다. 
- 이건 실제 의존성을 전부 불러오는 부분이라 말 그대로 로직이 잘 작동하는지 확인해 주세요.
- 각 Nested의 BeforeEach에서 상황 세팅을 최소한으로 해주세요 ( 이는 독립적인 테스트 마다 상황 설정을 하는 불편함을 줄이면서도 테스트간 의존성을 최소화 하기 위한 방법입니다. )

## 로그인
- 현재 로그인이 구현이 되지 않은 관계로 임시로 Fake 클래스를 만들었습니다.
- 임의의 멤버를 던지지만 사실상 Test에서 Mock하기 때문에 내부 로직은 크게 상관없습니다.
- 따라서, Swagger 테스트는 현재 쉽지 않고! Test Code로 검증 부탁드립니다.

## Sonarcloud
- 작업을 하면서 생성 로직에 대한 테스트 커버리지가 요구되는 경우, 우선은 임시로 제거 부탁드립니다.
- 이 부분에 대한 방법은 Sonarcloud 구현 PR에 있어요~!