### PR TITLE
[feat] 댓글 및 대댓글 작성 API 구현

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
@@ -1,0 +1,41 @@
+package org.clokey.domain.comment.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.clokey.code.GlobalBaseSuccessCode;
+import org.clokey.domain.comment.dto.request.CommentCreateRequest;
+import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
+import org.clokey.domain.comment.dto.response.CommentCreateResponse;
+import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
+import org.clokey.domain.comment.service.CommentService;
+import org.clokey.response.BaseResponse;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/comments")
+@RequiredArgsConstructor
+@Tag(name = "8. 댓글 API", description = "댓글 관련 API입니다.")
+@Validated
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    @Operation(summary = "댓글 작성", description = "새로운 댓글을 작성합니다.")
+    public BaseResponse<CommentCreateResponse> createComment(
+            @Valid @RequestBody CommentCreateRequest request) {
+        CommentCreateResponse response = commentService.createComment(request);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.CREATED, response);
+    }
+
+    @PostMapping("/{commentId}")
+    @Operation(summary = "대댓글 작성", description = "대댓글을 작성합니다.")
+    public BaseResponse<ReplyCreateResponse> createReply(
+            @PathVariable Long commentId, @Valid @RequestBody ReplyCreateRequest request) {
+        ReplyCreateResponse response = commentService.createReply(commentId, request);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.CREATED, response);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/dto/request/CommentCreateRequest.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,14 @@
+package org.clokey.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CommentCreateRequest(
+        @NotNull(message = "기록 ID는 비워둘 수 없습니다.") @Schema(description = "기록 ID", example = "1")
+                Long historyId,
+        @NotBlank(message = "댓글 내용을 비워둘 수 없습니다.")
+                @Size(max = 100, message = "댓글의 내용은 최대 100자까지 가능합니다.")
+                @Schema(description = "댓글의 내용", example = "이 옷 정보좀 알 수 있을까요!?")
+                String content) {}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/dto/request/ReplyCreateRequest.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/dto/request/ReplyCreateRequest.java
@@ -1,0 +1,11 @@
+package org.clokey.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ReplyCreateRequest(
+        @NotBlank(message = "대댓글 내용을 비워둘 수 없습니다.")
+                @Size(max = 100, message = "대댓글의 내용은 최대 100자까지 가능합니다.")
+                @Schema(description = "대댓글의 내용", example = "이 옷 정보좀 알 수 있을까요!?")
+                String content) {}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/dto/response/CommentCreateResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/dto/response/CommentCreateResponse.java
@@ -1,0 +1,11 @@
+package org.clokey.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.clokey.comment.entitiy.Comment;
+
+public record CommentCreateResponse(
+        @Schema(description = "작성된 댓글의 ID", example = "1") Long commentId) {
+    public static CommentCreateResponse from(Comment comment) {
+        return new CommentCreateResponse(comment.getId());
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/dto/response/ReplyCreateResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/dto/response/ReplyCreateResponse.java
@@ -1,0 +1,11 @@
+package org.clokey.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.clokey.comment.entitiy.Reply;
+
+public record ReplyCreateResponse(
+        @Schema(description = "작성된 대댓글의 ID", example = "1") Long replyId) {
+    public static ReplyCreateResponse from(Reply reply) {
+        return new ReplyCreateResponse(reply.getId());
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/exception/CommentErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/exception/CommentErrorCode.java
@@ -1,0 +1,20 @@
+package org.clokey.domain.comment.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.clokey.dto.ErrorReasonDto;
+import org.clokey.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum CommentErrorCode implements BaseErrorCode {
+    COMMENT_NOT_FOUND(404, "COMMENT_4041", "존재하지 않는 댓글입니다.");
+    private int status;
+    private String code;
+    private String message;
+
+    @Override
+    public ErrorReasonDto getErrorReason() {
+        return ErrorReasonDto.of(status, code, message);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentService.java
@@ -1,0 +1,13 @@
+package org.clokey.domain.comment.service;
+
+import org.clokey.domain.comment.dto.request.CommentCreateRequest;
+import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
+import org.clokey.domain.comment.dto.response.CommentCreateResponse;
+import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
+
+public interface CommentService {
+
+    CommentCreateResponse createComment(CommentCreateRequest request);
+
+    ReplyCreateResponse createReply(Long commentId, ReplyCreateRequest request);
+}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentServiceImpl.java
@@ -1,0 +1,78 @@
+package org.clokey.domain.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.clokey.comment.entitiy.Comment;
+import org.clokey.comment.entitiy.Reply;
+import org.clokey.domain.comment.dto.request.CommentCreateRequest;
+import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
+import org.clokey.domain.comment.dto.response.CommentCreateResponse;
+import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
+import org.clokey.domain.comment.exception.CommentErrorCode;
+import org.clokey.domain.comment.repository.CommentRepository;
+import org.clokey.domain.comment.repository.ReplyRepository;
+import org.clokey.domain.history.exception.HistoryErrorCode;
+import org.clokey.domain.history.repository.HistoryRepository;
+import org.clokey.exception.BaseCustomException;
+import org.clokey.global.FakeAuthContext;
+import org.clokey.history.entity.History;
+import org.clokey.member.entity.Member;
+import org.clokey.member.enums.Visibility;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentServiceImpl implements CommentService {
+
+    private final FakeAuthContext fakeAuthContext;
+
+    private final CommentRepository commentRepository;
+    private final HistoryRepository historyRepository;
+    private final ReplyRepository replyRepository;
+
+    @Override
+    public CommentCreateResponse createComment(CommentCreateRequest request) {
+        final Member currentMember = fakeAuthContext.getCurrentMember();
+        final History history = getHistoryById(request.historyId());
+
+        validateHistoryAuthority(currentMember, history);
+
+        Comment comment = Comment.createComment(request.content(), currentMember, history);
+        commentRepository.save(comment);
+
+        return CommentCreateResponse.from(comment);
+    }
+
+    @Override
+    public ReplyCreateResponse createReply(Long commentId, ReplyCreateRequest request) {
+        final Member currentMember = fakeAuthContext.getCurrentMember();
+        final Comment comment = getCommentById(commentId);
+
+        validateHistoryAuthority(currentMember, comment.getHistory());
+
+        Reply reply = Reply.createReply(request.content(), currentMember, comment);
+        replyRepository.save(reply);
+
+        return ReplyCreateResponse.from(reply);
+    }
+
+    private void validateHistoryAuthority(Member member, History history) {
+        if (history.getMember().getVisibility().equals(Visibility.PRIVATE)
+                || !history.getMember().getId().equals(member.getId())) {
+            throw new BaseCustomException(HistoryErrorCode.LIMITED_AUTHORITY);
+        }
+    }
+
+    private History getHistoryById(Long historyId) {
+        return historyRepository
+                .findById(historyId)
+                .orElseThrow(() -> new BaseCustomException(HistoryErrorCode.HISTORY_NOT_FOUND));
+    }
+
+    private Comment getCommentById(Long commentId) {
+        return commentRepository
+                .findById(commentId)
+                .orElseThrow(() -> new BaseCustomException(CommentErrorCode.COMMENT_NOT_FOUND));
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/history/exception/HistoryErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/history/exception/HistoryErrorCode.java
@@ -1,0 +1,22 @@
+package org.clokey.domain.history.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.clokey.dto.ErrorReasonDto;
+import org.clokey.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum HistoryErrorCode implements BaseErrorCode {
+    HISTORY_NOT_FOUND(404, "HISTORY_4041", "존재하지 않는 기록입니다."),
+    LIMITED_AUTHORITY(403, "HISTORY_4031", "기록에 대한 접근 권한이 없습니다.");
+
+    private int status;
+    private String code;
+    private String message;
+
+    @Override
+    public ErrorReasonDto getErrorReason() {
+        return ErrorReasonDto.of(status, code, message);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/history/repository/HistoryTypeRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/history/repository/HistoryTypeRepository.java
@@ -1,0 +1,6 @@
+package org.clokey.domain.history.repository;
+
+import org.clokey.history.entity.HistoryType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HistoryTypeRepository extends JpaRepository<HistoryType, Long> {}

--- a/clokey-api/src/test/java/org/clokey/domain/cloth/controller/ClothControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/cloth/controller/ClothControllerTest.java
@@ -41,7 +41,7 @@ class ClothControllerTest {
     class 옷_생성_요청_시 {
 
         @Test
-        void 유효한_요청이면_생성된_옷_ID를_반환한다() throws Exception {
+        void 유효한_요청이면_옷을_생성하고_ID를_반환한다() throws Exception {
             // given
             ClothCreateRequests request =
                     new ClothCreateRequests(

--- a/clokey-api/src/test/java/org/clokey/domain/cloth/service/ClothServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/cloth/service/ClothServiceTest.java
@@ -2,7 +2,6 @@ package org.clokey.domain.cloth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
 import java.util.List;

--- a/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
@@ -1,0 +1,254 @@
+package org.clokey.domain.comment.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.clokey.domain.comment.dto.request.CommentCreateRequest;
+import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
+import org.clokey.domain.comment.dto.response.CommentCreateResponse;
+import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
+import org.clokey.domain.comment.exception.CommentErrorCode;
+import org.clokey.domain.comment.service.CommentService;
+import org.clokey.domain.history.exception.HistoryErrorCode;
+import org.clokey.exception.BaseCustomException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(CommentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CommentControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private CommentService commentService;
+
+    @Nested
+    class 댓글_작성_요청_시 {
+
+        @Test
+        void 유효한_요청이면_댓글을_생성하고_ID를_반환한다() throws Exception {
+            // given
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
+            CommentCreateResponse response = new CommentCreateResponse(1L);
+
+            given(commentService.createComment(request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/comments")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON201"))
+                    .andExpect(jsonPath("$.message").value("요청 성공 및 리소스 생성됨"))
+                    .andExpect(jsonPath("$.result.commentId").value(1));
+        }
+
+        @Test
+        void 기록_ID를_비워두면_예외가_발생한다() throws Exception {
+            // given
+            CommentCreateRequest request = new CommentCreateRequest(null, "testContent");
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/comments")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.historyId").value("기록 ID는 비워둘 수 없습니다."));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void 댓글_내용이_null_또는_공백이면_예외가_발생한다(String content) throws Exception {
+            // given
+            CommentCreateRequest request = new CommentCreateRequest(1L, content);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/comments")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.content").value("댓글 내용을 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 댓글의_길이가_100자를_넘어가면_예외가_발생한다() throws Exception {
+            // given
+            CommentCreateRequest request = new CommentCreateRequest(1L, "t".repeat(101));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/comments")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.content").value("댓글의 내용은 최대 100자까지 가능합니다."));
+        }
+
+        @Test
+        void 기록이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            CommentCreateRequest request = new CommentCreateRequest(999L, "testContent");
+            given(commentService.createComment(request))
+                    .willThrow(new BaseCustomException(HistoryErrorCode.HISTORY_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/comments")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("HISTORY_4041"))
+                    .andExpect(jsonPath("$.message").value("존재하지 않는 기록입니다."));
+        }
+
+        @Test
+        void 내가_아닌_비공개_계정의_기록에_댓글을_작성하면_예외가_발생한다() throws Exception {
+            // given
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
+            given(commentService.createComment(request))
+                    .willThrow(new BaseCustomException(HistoryErrorCode.LIMITED_AUTHORITY));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/comments")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("HISTORY_4031"))
+                    .andExpect(jsonPath("$.message").value("기록에 대한 접근 권한이 없습니다."));
+        }
+    }
+
+    @Nested
+    class 대댓글_작성_요청_시 {
+
+        @Test
+        void 유효한_요청이면_대댓글을_생성하고_ID를_반환한다() throws Exception {
+            // given
+            ReplyCreateRequest request = new ReplyCreateRequest("testContent");
+            ReplyCreateResponse response = new ReplyCreateResponse(1L);
+
+            given(commentService.createReply(1L, request)).willReturn(response);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/comments/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON201"))
+                    .andExpect(jsonPath("$.message").value("요청 성공 및 리소스 생성됨"))
+                    .andExpect(jsonPath("$.result.replyId").value(1));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void 대댓글_내용이_null_또는_공백이면_예외가_발생한다(String content) throws Exception {
+            // given
+            ReplyCreateRequest request = new ReplyCreateRequest(content);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/comments/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.content").value("대댓글 내용을 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 댓글이_존재하지_않는_경우_예외가_발생한다() throws Exception {
+            // given
+            ReplyCreateRequest request = new ReplyCreateRequest("testContent");
+            given(commentService.createReply(1L, request))
+                    .willThrow(new BaseCustomException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/comments/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMENT_4041"))
+                    .andExpect(jsonPath("$.message").value("존재하지 않는 댓글입니다."));
+        }
+
+        @Test
+        void 내가_아닌_비공개_계정의_기록의_댓글에_대댓글을_작성하면_예외가_발생한다() throws Exception {
+            // given
+            ReplyCreateRequest request = new ReplyCreateRequest("testContent");
+            given(commentService.createReply(1L, request))
+                    .willThrow(new BaseCustomException(HistoryErrorCode.LIMITED_AUTHORITY));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/comments/1")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("HISTORY_4031"))
+                    .andExpect(jsonPath("$.message").value("기록에 대한 접근 권한이 없습니다."));
+        }
+    }
+}

--- a/clokey-api/src/test/java/org/clokey/domain/comment/service/CommentServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,206 @@
+package org.clokey.domain.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.clokey.IntegrationTest;
+import org.clokey.comment.entitiy.Comment;
+import org.clokey.comment.entitiy.Reply;
+import org.clokey.domain.comment.dto.request.CommentCreateRequest;
+import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
+import org.clokey.domain.comment.exception.CommentErrorCode;
+import org.clokey.domain.comment.repository.CommentRepository;
+import org.clokey.domain.comment.repository.ReplyRepository;
+import org.clokey.domain.history.exception.HistoryErrorCode;
+import org.clokey.domain.history.repository.HistoryRepository;
+import org.clokey.domain.history.repository.HistoryTypeRepository;
+import org.clokey.domain.member.repository.MemberRepository;
+import org.clokey.exception.BaseCustomException;
+import org.clokey.global.FakeAuthContext;
+import org.clokey.history.entity.History;
+import org.clokey.history.entity.HistoryType;
+import org.clokey.member.entity.Member;
+import org.clokey.member.entity.OauthInfo;
+import org.clokey.member.enums.MemberStatus;
+import org.clokey.member.enums.OauthProvider;
+import org.clokey.member.enums.RegisterStatus;
+import org.clokey.member.enums.Visibility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class CommentServiceTest extends IntegrationTest {
+
+    @Autowired CommentService commentService;
+    @Autowired CommentRepository commentRepository;
+    @Autowired ReplyRepository replyRepository;
+    @Autowired HistoryRepository historyRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired HistoryTypeRepository historyTypeRepository;
+
+    @MockitoBean FakeAuthContext fakeAuthContext;
+
+    @Nested
+    class 댓글을_작성할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            "testEmail1",
+                            "testClokeyId1",
+                            "testNickName1",
+                            OauthInfo.createOauthInfo("testOauthId1", OauthProvider.KAKAO),
+                            MemberStatus.ACTIVE,
+                            RegisterStatus.REGISTERED,
+                            Visibility.PUBLIC);
+            Member member2 =
+                    Member.createMember(
+                            "testEmail2",
+                            "testClokeyId2",
+                            "testNickName2",
+                            OauthInfo.createOauthInfo("testOauthId2", OauthProvider.KAKAO),
+                            MemberStatus.ACTIVE,
+                            RegisterStatus.REGISTERED,
+                            Visibility.PRIVATE);
+
+            memberRepository.saveAll(List.of(member1, member2));
+            given(fakeAuthContext.getCurrentMember()).willReturn(member1);
+
+            HistoryType historyType = HistoryType.createHistoryType("testType");
+            historyTypeRepository.save(historyType);
+
+            History history1 =
+                    History.creatHistory(
+                            LocalDate.of(2025, 1, 1), "testContent1", member1, historyType);
+            History history2 =
+                    History.creatHistory(
+                            LocalDate.of(2025, 1, 1), "testContent2", member2, historyType);
+            historyRepository.saveAll(List.of(history1, history2));
+        }
+
+        @Test
+        void 유효한_요청이면_댓글을_생성한다() {
+            // given
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
+
+            // when
+            commentService.createComment(request);
+
+            // then
+            Comment comment = commentRepository.findById(1L).orElseThrow();
+            assertThat(comment)
+                    .extracting("content", "banned", "member.id", "history.id")
+                    .containsExactly("testContent1", false, 1L, 1L);
+        }
+
+        @Test
+        void 기록이_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            CommentCreateRequest request = new CommentCreateRequest(999L, "testContent");
+
+            // when & then
+            assertThatThrownBy(() -> commentService.createComment(request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(HistoryErrorCode.HISTORY_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 내가_아닌_비공개_계정의_기록에_댓글을_작성하면_예외가_발생한다() {
+            // given
+            CommentCreateRequest request = new CommentCreateRequest(2L, "testContent");
+
+            // when & then
+            assertThatThrownBy(() -> commentService.createComment(request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(HistoryErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+    }
+
+    @Nested
+    class 대댓글을_작성할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            "testEmail1",
+                            "testClokeyId1",
+                            "testNickName1",
+                            OauthInfo.createOauthInfo("testOauthId1", OauthProvider.KAKAO),
+                            MemberStatus.ACTIVE,
+                            RegisterStatus.REGISTERED,
+                            Visibility.PUBLIC);
+            Member member2 =
+                    Member.createMember(
+                            "testEmail2",
+                            "testClokeyId2",
+                            "testNickName2",
+                            OauthInfo.createOauthInfo("testOauthId2", OauthProvider.KAKAO),
+                            MemberStatus.ACTIVE,
+                            RegisterStatus.REGISTERED,
+                            Visibility.PRIVATE);
+
+            memberRepository.saveAll(List.of(member1, member2));
+            given(fakeAuthContext.getCurrentMember()).willReturn(member1);
+
+            HistoryType historyType = HistoryType.createHistoryType("testType");
+            historyTypeRepository.save(historyType);
+
+            History history1 =
+                    History.creatHistory(
+                            LocalDate.of(2025, 1, 1), "testContent1", member1, historyType);
+            History history2 =
+                    History.creatHistory(
+                            LocalDate.of(2025, 1, 1), "testContent2", member2, historyType);
+            historyRepository.saveAll(List.of(history1, history2));
+
+            Comment comment1 = Comment.createComment("testContent1", member1, history1);
+            Comment comment2 = Comment.createComment("testContent2", member2, history2);
+            commentRepository.saveAll(List.of(comment1, comment2));
+        }
+
+        @Test
+        void 유효한_요청이면_대댓글을_생성한다() {
+            // given
+            ReplyCreateRequest request = new ReplyCreateRequest("testContent");
+
+            // when
+            commentService.createReply(1L, request);
+
+            // then
+            Reply reply = replyRepository.findById(1L).orElseThrow();
+            assertThat(reply)
+                    .extracting("content", "banned", "member.id", "comment.id")
+                    .containsExactly("testContent", false, 1L, 1L);
+        }
+
+        @Test
+        void 댓글이_존재하지_않는_경우_예외가_발생한다() {
+            // given
+            ReplyCreateRequest request = new ReplyCreateRequest("testContent");
+
+            // when & then
+            assertThatThrownBy(() -> commentService.createReply(999L, request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(CommentErrorCode.COMMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 내가_아닌_비공개_계정의_기록에_작성된_댓글에_대댓글을_작성하면_예외가_발생한다() {
+            // given
+            ReplyCreateRequest request = new ReplyCreateRequest("testContent");
+
+            // when & then
+            assertThatThrownBy(() -> commentService.createReply(2L, request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(HistoryErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+    }
+}

--- a/clokey-domain/src/main/java/org/clokey/comment/entitiy/Comment.java
+++ b/clokey-domain/src/main/java/org/clokey/comment/entitiy/Comment.java
@@ -32,6 +32,23 @@ public class Comment extends BaseEntity {
     @NotNull
     private History history;
 
+    @Builder(access = AccessLevel.PRIVATE)
+    private Comment(String content, boolean banned, Member member, History history) {
+        this.content = content;
+        this.banned = banned;
+        this.member = member;
+        this.history = history;
+    }
+
+    public static Comment createComment(String content, Member member, History history) {
+        return Comment.builder()
+                .content(content)
+                .banned(false)
+                .member(member)
+                .history(history)
+                .build();
+    }
+
     //    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
     //    private List<Reply> replies = new ArrayList<>();
 

--- a/clokey-domain/src/main/java/org/clokey/comment/entitiy/Reply.java
+++ b/clokey-domain/src/main/java/org/clokey/comment/entitiy/Reply.java
@@ -3,6 +3,7 @@ package org.clokey.comment.entitiy;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.clokey.common.model.BaseEntity;
@@ -32,4 +33,21 @@ public class Reply extends BaseEntity {
     @JoinColumn(name = "comment_id")
     @NotNull
     private Comment comment;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Reply(String content, boolean banned, Member member, Comment comment) {
+        this.content = content;
+        this.banned = banned;
+        this.member = member;
+        this.comment = comment;
+    }
+
+    public static Reply createReply(String content, Member member, Comment comment) {
+        return Reply.builder()
+                .content(content)
+                .banned(false)
+                .member(member)
+                .comment(comment)
+                .build();
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/history/entity/History.java
+++ b/clokey-domain/src/main/java/org/clokey/history/entity/History.java
@@ -39,4 +39,29 @@ public class History extends BaseEntity {
     @JoinColumn(name = "history_type_id")
     @NotNull
     private HistoryType historyType;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private History(
+            LocalDate historyDate,
+            String content,
+            boolean banned,
+            Member member,
+            HistoryType historyType) {
+        this.historyDate = historyDate;
+        this.content = content;
+        this.banned = banned;
+        this.member = member;
+        this.historyType = historyType;
+    }
+
+    public static History creatHistory(
+            LocalDate historyDate, String content, Member member, HistoryType historyType) {
+        return History.builder()
+                .historyDate(historyDate)
+                .content(content)
+                .banned(false)
+                .member(member)
+                .historyType(historyType)
+                .build();
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/history/entity/HistoryType.java
+++ b/clokey-domain/src/main/java/org/clokey/history/entity/HistoryType.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.clokey.common.model.BaseEntity;
@@ -20,4 +21,13 @@ public class HistoryType extends BaseEntity {
     private Long id;
 
     @NotNull private String name;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private HistoryType(String name) {
+        this.name = name;
+    }
+
+    public static HistoryType createHistoryType(String name) {
+        return HistoryType.builder().name(name).build();
+    }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #23 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 댓글 및 대댓글 작성 API 구현

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 댓글 및 대댓글 작성 API를 구현했습니다.
- 기존에는 하나의 API였지만, 엔티티가 분리되면서 API역시 분리를 했습니다.

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
- 다른 부분들의 생성자를 만들어서 사용했습니다.
- 이는 기록 생성 API와 충돌이 있을 수 있습니다. PR이 머지된 후에 리베이스 부탁드립니다 @Ssamssamukja 
