### PR TITLE
[feat/28] 기록의 댓글 목록 조회 API 구현 

### DIFF
--- a/clokey-api/build.gradle
+++ b/clokey-api/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation project(':clokey-common')
     implementation project(':clokey-infrastructure')
     implementation project(':clokey-common-web')
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package org.clokey.domain.comment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -8,9 +9,13 @@ import org.clokey.code.GlobalBaseSuccessCode;
 import org.clokey.domain.comment.dto.request.CommentCreateRequest;
 import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
 import org.clokey.domain.comment.dto.response.CommentCreateResponse;
+import org.clokey.domain.comment.dto.response.CommentListResponse;
 import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
 import org.clokey.domain.comment.service.CommentService;
+import org.clokey.global.annotation.PageSize;
+import org.clokey.global.paging.SortDirection;
 import org.clokey.response.BaseResponse;
+import org.clokey.response.SliceResponse;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,6 +41,22 @@ public class CommentController {
     public BaseResponse<ReplyCreateResponse> createReply(
             @PathVariable Long commentId, @Valid @RequestBody ReplyCreateRequest request) {
         ReplyCreateResponse response = commentService.createReply(commentId, request);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.CREATED, response);
+    }
+
+    @GetMapping
+    @Operation(summary = "댓글 조회", description = "댓글을 조회합니다")
+    public BaseResponse<SliceResponse<CommentListResponse>> getComments(
+            @Parameter(description = "조회중인 기록의 ID") @RequestParam Long historyId,
+            @Parameter(description = "이전 페이지의 마지막 댓글 ID (첫 요청 시 생략)")
+                    @RequestParam(required = false)
+                    Long lastCommentId,
+            @Parameter(description = "페이지당 조회할 댓글 수") @RequestParam @PageSize Integer size,
+            @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
+                    @RequestParam(defaultValue = "DESC")
+                    SortDirection direction) {
+        SliceResponse<CommentListResponse> response =
+                commentService.getHistoryComments(historyId, lastCommentId, size, direction);
         return BaseResponse.onSuccess(GlobalBaseSuccessCode.CREATED, response);
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
@@ -36,7 +36,7 @@ public class CommentController {
         return BaseResponse.onSuccess(GlobalBaseSuccessCode.CREATED, response);
     }
 
-    @PostMapping("/{commentId}")
+    @PostMapping("/{commentId}/replies")
     @Operation(summary = "대댓글 작성", description = "대댓글을 작성합니다.")
     public BaseResponse<ReplyCreateResponse> createReply(
             @PathVariable Long commentId, @Valid @RequestBody ReplyCreateRequest request) {

--- a/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
@@ -57,6 +57,6 @@ public class CommentController {
                     SortDirection direction) {
         SliceResponse<CommentListResponse> response =
                 commentService.getHistoryComments(historyId, lastCommentId, size, direction);
-        return BaseResponse.onSuccess(GlobalBaseSuccessCode.CREATED, response);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.OK, response);
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/comment/dto/response/CommentListResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/dto/response/CommentListResponse.java
@@ -1,0 +1,11 @@
+package org.clokey.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CommentListResponse(
+        @Schema(description = "댓글 ID", example = "1") Long commentId,
+        @Schema(description = "댓글 작성자 ID", example = "1") Long memberId,
+        @Schema(description = "댓글 작성자 닉네임", example = "포테토남") String nickName,
+        @Schema(description = "댓글 작성자 이미지 주소", example = "https://s3.amazonaws.com/example.jpg")
+                String profileImageUrl,
+        @Schema(description = "댓글 내용", example = "이 옷 정보 알려주세요!") String content) {}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/dto/response/CommentListResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/dto/response/CommentListResponse.java
@@ -8,4 +8,5 @@ public record CommentListResponse(
         @Schema(description = "댓글 작성자 닉네임", example = "포테토남") String nickName,
         @Schema(description = "댓글 작성자 이미지 주소", example = "https://s3.amazonaws.com/example.jpg")
                 String profileImageUrl,
-        @Schema(description = "댓글 내용", example = "이 옷 정보 알려주세요!") String content) {}
+        @Schema(description = "댓글 내용", example = "이 옷 정보 알려주세요!") String content,
+        @Schema(description = "대댓글 존재 여부", example = "false") boolean replied) {}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/repository/CommentRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/repository/CommentRepository.java
@@ -3,4 +3,4 @@ package org.clokey.domain.comment.repository;
 import org.clokey.comment.entitiy.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {}
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/repository/CommentRepositoryCustom.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.clokey.domain.comment.repository;
+
+import org.clokey.domain.comment.dto.response.CommentListResponse;
+import org.clokey.global.paging.SortDirection;
+import org.springframework.data.domain.Slice;
+
+public interface CommentRepositoryCustom {
+    Slice<CommentListResponse> findAllByHistoryId(
+            Long historyId, Long lastHistoryId, int size, SortDirection direction);
+}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/repository/CommentRepositoryImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/repository/CommentRepositoryImpl.java
@@ -1,0 +1,72 @@
+package org.clokey.domain.comment.repository;
+
+import static org.clokey.comment.entitiy.QComment.comment;
+import static org.clokey.member.entity.QMember.member;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.clokey.domain.comment.dto.response.CommentListResponse;
+import org.clokey.global.paging.SortDirection;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<CommentListResponse> findAllByHistoryId(
+            Long historyId, Long lastCommentId, int size, SortDirection direction) {
+        List<CommentListResponse> results =
+                queryFactory
+                        .select(
+                                Projections.constructor(
+                                        CommentListResponse.class,
+                                        comment.id,
+                                        member.id,
+                                        member.nickname,
+                                        member.profileImageUrl,
+                                        comment.content))
+                        .from(comment)
+                        .join(comment.member, member)
+                        .where(
+                                comment.member.id.eq(member.id),
+                                lastCommentIdCondition(lastCommentId, direction))
+                        .orderBy(
+                                direction == SortDirection.DESC
+                                        ? comment.id.desc()
+                                        : comment.id.asc())
+                        .limit(size + 1)
+                        .fetch();
+
+        return checkLastPage(size, results);
+    }
+
+    private BooleanExpression lastCommentIdCondition(Long commentId, SortDirection direction) {
+        if (commentId == null) {
+            return null;
+        }
+
+        return direction == SortDirection.DESC
+                ? comment.id.lt(commentId)
+                : comment.id.gt(commentId);
+    }
+
+    private <T> Slice<T> checkLastPage(int pageSize, List<T> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/repository/CommentRepositoryImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/repository/CommentRepositoryImpl.java
@@ -1,12 +1,16 @@
 package org.clokey.domain.comment.repository;
 
 import static org.clokey.comment.entitiy.QComment.comment;
+import static org.clokey.comment.entitiy.QReply.reply;
 import static org.clokey.member.entity.QMember.member;
 
+import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.clokey.domain.comment.dto.response.CommentListResponse;
 import org.clokey.global.paging.SortDirection;
@@ -24,6 +28,8 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     @Override
     public Slice<CommentListResponse> findAllByHistoryId(
             Long historyId, Long lastCommentId, int size, SortDirection direction) {
+
+        // 삼중 조인을 피하기 위해 댓글 존재 여부는 처음에는 false로 가져옵니다.
         List<CommentListResponse> results =
                 queryFactory
                         .select(
@@ -33,11 +39,12 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                                         member.id,
                                         member.nickname,
                                         member.profileImageUrl,
-                                        comment.content))
+                                        comment.content,
+                                        Expressions.constant(false)))
                         .from(comment)
                         .join(comment.member, member)
                         .where(
-                                comment.member.id.eq(member.id),
+                                comment.history.id.eq(historyId),
                                 lastCommentIdCondition(lastCommentId, direction))
                         .orderBy(
                                 direction == SortDirection.DESC
@@ -46,7 +53,41 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                         .limit(size + 1)
                         .fetch();
 
-        return checkLastPage(size, results);
+        boolean hasNext = results.size() > size;
+        if (hasNext) {
+            results = results.subList(0, size);
+        }
+
+        Map<Long, Boolean> repliedMap =
+                results.isEmpty()
+                        ? Map.of()
+                        : queryFactory
+                                .select(reply.comment.id)
+                                .from(reply)
+                                .where(
+                                        reply.comment.id.in(
+                                                results.stream()
+                                                        .map(CommentListResponse::commentId)
+                                                        .toList()))
+                                .groupBy(reply.comment.id)
+                                .transform(
+                                        GroupBy.groupBy(reply.comment.id)
+                                                .as(Expressions.constant(true)));
+
+        List<CommentListResponse> finalResults =
+                results.stream()
+                        .map(
+                                c ->
+                                        new CommentListResponse(
+                                                c.commentId(),
+                                                c.memberId(),
+                                                c.nickName(),
+                                                c.profileImageUrl(),
+                                                c.content(),
+                                                repliedMap.getOrDefault(c.commentId(), false)))
+                        .toList();
+
+        return checkLastPage(size, finalResults);
     }
 
     private BooleanExpression lastCommentIdCondition(Long commentId, SortDirection direction) {

--- a/clokey-api/src/main/java/org/clokey/domain/comment/repository/CommentRepositoryImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/repository/CommentRepositoryImpl.java
@@ -87,7 +87,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                                                 repliedMap.getOrDefault(c.commentId(), false)))
                         .toList();
 
-        return checkLastPage(size, finalResults);
+        return new SliceImpl<>(finalResults, PageRequest.of(0, size), hasNext);
     }
 
     private BooleanExpression lastCommentIdCondition(Long commentId, SortDirection direction) {
@@ -98,16 +98,5 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
         return direction == SortDirection.DESC
                 ? comment.id.lt(commentId)
                 : comment.id.gt(commentId);
-    }
-
-    private <T> Slice<T> checkLastPage(int pageSize, List<T> results) {
-        boolean hasNext = false;
-
-        if (results.size() > pageSize) {
-            hasNext = true;
-            results.remove(pageSize);
-        }
-
-        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentService.java
@@ -3,11 +3,17 @@ package org.clokey.domain.comment.service;
 import org.clokey.domain.comment.dto.request.CommentCreateRequest;
 import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
 import org.clokey.domain.comment.dto.response.CommentCreateResponse;
+import org.clokey.domain.comment.dto.response.CommentListResponse;
 import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
+import org.clokey.global.paging.SortDirection;
+import org.clokey.response.SliceResponse;
 
 public interface CommentService {
 
     CommentCreateResponse createComment(CommentCreateRequest request);
 
     ReplyCreateResponse createReply(Long commentId, ReplyCreateRequest request);
+
+    SliceResponse<CommentListResponse> getHistoryComments(
+            Long historyId, Long lastCommentId, int size, SortDirection direction);
 }

--- a/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentServiceImpl.java
@@ -45,7 +45,13 @@ public class CommentServiceImpl implements CommentService {
         try {
             commentRepository.save(comment);
         } catch (DataIntegrityViolationException e) {
-            throw new BaseCustomException(HistoryErrorCode.HISTORY_NOT_FOUND);
+            String message = e.getMostSpecificCause().getMessage();
+
+            if (message != null && message.contains("fk_comment_history")) {
+                throw new BaseCustomException(CommentErrorCode.COMMENT_NOT_FOUND);
+            }
+
+            throw e;
         }
 
         return CommentCreateResponse.from(comment);
@@ -64,7 +70,13 @@ public class CommentServiceImpl implements CommentService {
         try {
             replyRepository.save(reply);
         } catch (DataIntegrityViolationException e) {
-            throw new BaseCustomException(CommentErrorCode.COMMENT_NOT_FOUND);
+            String message = e.getMostSpecificCause().getMessage();
+
+            if (message != null && message.contains("fk_reply_comment")) {
+                throw new BaseCustomException(CommentErrorCode.COMMENT_NOT_FOUND);
+            }
+
+            throw e;
         }
 
         return ReplyCreateResponse.from(reply);

--- a/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentServiceImpl.java
@@ -6,6 +6,7 @@ import org.clokey.comment.entitiy.Reply;
 import org.clokey.domain.comment.dto.request.CommentCreateRequest;
 import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
 import org.clokey.domain.comment.dto.response.CommentCreateResponse;
+import org.clokey.domain.comment.dto.response.CommentListResponse;
 import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
 import org.clokey.domain.comment.exception.CommentErrorCode;
 import org.clokey.domain.comment.repository.CommentRepository;
@@ -14,10 +15,13 @@ import org.clokey.domain.history.exception.HistoryErrorCode;
 import org.clokey.domain.history.repository.HistoryRepository;
 import org.clokey.exception.BaseCustomException;
 import org.clokey.global.FakeAuthContext;
+import org.clokey.global.paging.SortDirection;
 import org.clokey.history.entity.History;
 import org.clokey.member.entity.Member;
 import org.clokey.member.enums.Visibility;
+import org.clokey.response.SliceResponse;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,6 +84,19 @@ public class CommentServiceImpl implements CommentService {
         }
 
         return ReplyCreateResponse.from(reply);
+    }
+
+    @Override
+    public SliceResponse<CommentListResponse> getHistoryComments(
+            Long historyId, Long lastCommentId, int size, SortDirection direction) {
+        final Member currentMember = fakeAuthContext.getCurrentMember();
+        final History history = getHistoryById(historyId);
+
+        validateHistoryAuthority(currentMember, history);
+
+        Slice<CommentListResponse> result =
+                commentRepository.findAllByHistoryId(historyId, lastCommentId, size, direction);
+        return SliceResponse.from(result);
     }
 
     private void validateHistoryAuthority(Member member, History history) {

--- a/clokey-api/src/main/java/org/clokey/global/annotation/Enum.java
+++ b/clokey-api/src/main/java/org/clokey/global/annotation/Enum.java
@@ -1,0 +1,21 @@
+package org.clokey.global.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.clokey.global.validator.EnumValidator;
+
+/** RequestBody 의 Enum 검증을 위한 어노테이션 입니다 (Query Parameter 불가) */
+@Constraint(validatedBy = {EnumValidator.class})
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Enum {
+    String message() default "적절하지 않은 Enum값 입니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/clokey-api/src/main/java/org/clokey/global/annotation/PageSize.java
+++ b/clokey-api/src/main/java/org/clokey/global/annotation/PageSize.java
@@ -1,0 +1,21 @@
+package org.clokey.global.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.clokey.global.validator.PageSizeValidator;
+
+/** Query Parameter 의 PageSize 검증을 위한 어노테이션 입니다 */
+@Constraint(validatedBy = PageSizeValidator.class)
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PageSize {
+    String message() default "페이지 크기는 0보다 큰 값만 가능합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/clokey-api/src/main/java/org/clokey/global/paging/SortDirection.java
+++ b/clokey-api/src/main/java/org/clokey/global/paging/SortDirection.java
@@ -1,0 +1,6 @@
+package org.clokey.global.paging;
+
+public enum SortDirection {
+    ASC,
+    DESC
+}

--- a/clokey-api/src/main/java/org/clokey/global/validator/EnumValidator.java
+++ b/clokey-api/src/main/java/org/clokey/global/validator/EnumValidator.java
@@ -1,0 +1,12 @@
+package org.clokey.global.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.clokey.global.annotation.Enum;
+
+public class EnumValidator implements ConstraintValidator<Enum, java.lang.Enum> {
+    @Override
+    public boolean isValid(java.lang.Enum value, ConstraintValidatorContext context) {
+        return value != null;
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/global/validator/PageSizeValidator.java
+++ b/clokey-api/src/main/java/org/clokey/global/validator/PageSizeValidator.java
@@ -1,0 +1,18 @@
+package org.clokey.global.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.clokey.global.annotation.PageSize;
+
+public class PageSizeValidator implements ConstraintValidator<PageSize, Integer> {
+
+    @Override
+    public void initialize(PageSize constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        return value != null && value > 0;
+    }
+}

--- a/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
@@ -258,7 +258,7 @@ class CommentControllerTest {
     }
 
     @Nested
-    class 기록의_댓글_조회_요청_시 {
+    class 기록의_댓글_목록_조회_요청_시 {
 
         @Test
         void 정렬_조건이_ASC이면_commentId를_오름차순으로_응답한다() throws Exception {

--- a/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
@@ -178,7 +178,7 @@ class CommentControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/comments/1")
+                            post("/comments/1/replies")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -200,7 +200,7 @@ class CommentControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/comments/1")
+                            post("/comments/1/replies")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -221,7 +221,7 @@ class CommentControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/comments/1")
+                            post("/comments/1/replies")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 
@@ -241,7 +241,7 @@ class CommentControllerTest {
             // when & then
             ResultActions perform =
                     mockMvc.perform(
-                            post("/comments/1")
+                            post("/comments/1/replies")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)));
 

--- a/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
@@ -2,19 +2,24 @@ package org.clokey.domain.comment.controller;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.clokey.domain.comment.dto.request.CommentCreateRequest;
 import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
 import org.clokey.domain.comment.dto.response.CommentCreateResponse;
+import org.clokey.domain.comment.dto.response.CommentListResponse;
 import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
 import org.clokey.domain.comment.exception.CommentErrorCode;
 import org.clokey.domain.comment.service.CommentService;
 import org.clokey.domain.history.exception.HistoryErrorCode;
 import org.clokey.exception.BaseCustomException;
+import org.clokey.global.paging.SortDirection;
+import org.clokey.response.SliceResponse;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -249,6 +254,180 @@ class CommentControllerTest {
                     .andExpect(jsonPath("$.isSuccess").value(false))
                     .andExpect(jsonPath("$.code").value("HISTORY_4031"))
                     .andExpect(jsonPath("$.message").value("기록에 대한 접근 권한이 없습니다."));
+        }
+    }
+
+    @Nested
+    class 기록의_댓글_조회_요청_시 {
+
+        @Test
+        void 정렬_조건이_ASC이면_commentId를_오름차순으로_응답한다() throws Exception {
+            // given
+            List<CommentListResponse> historyComments =
+                    List.of(
+                            new CommentListResponse(
+                                    1L, 1L, "testNickName", "testProfile", "testContent1", false),
+                            new CommentListResponse(
+                                    2L, 1L, "testNickName", "testProfile", "testContent2", false));
+
+            given(commentService.getHistoryComments(1L, null, 2, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(historyComments, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments")
+                                    .param("historyId", "1")
+                                    .param("size", "2")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.result.content[0].commentId").value(1))
+                    .andExpect(jsonPath("$.result.content[1].commentId").value(2))
+                    .andExpect(jsonPath("$.result.isLast").value(true));
+        }
+
+        @Test
+        void 정렬_조건이_DESC이면_commentId를_내림차순으로_응답한다() throws Exception {
+            // given
+            List<CommentListResponse> historyComments =
+                    List.of(
+                            new CommentListResponse(
+                                    2L, 1L, "testNickName", "testProfile", "testContent2", false),
+                            new CommentListResponse(
+                                    1L, 1L, "testNickName", "testProfile", "testContent1", false));
+
+            given(commentService.getHistoryComments(1L, null, 2, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(historyComments, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments")
+                                    .param("historyId", "1")
+                                    .param("size", "2")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.result.content[0].commentId").value(2))
+                    .andExpect(jsonPath("$.result.content[1].commentId").value(1))
+                    .andExpect(jsonPath("$.result.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
+            // given
+            List<CommentListResponse> historyComments =
+                    List.of(
+                            new CommentListResponse(
+                                    2L, 1L, "testNickName", "testProfile", "testContent2", false));
+
+            given(commentService.getHistoryComments(1L, null, 1, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(historyComments, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments")
+                                    .param("historyId", "1")
+                                    .param("size", "1")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.result.content[0].commentId").value(2))
+                    .andExpect(jsonPath("$.result.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_응답한다() throws Exception {
+            // given
+            List<CommentListResponse> historyComments =
+                    List.of(
+                            new CommentListResponse(
+                                    1L, 1L, "testNickName", "testProfile", "testContent1", false),
+                            new CommentListResponse(
+                                    2L, 1L, "testNickName", "testProfile", "testContent2", false));
+
+            given(commentService.getHistoryComments(1L, null, 1, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(historyComments, false));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments")
+                                    .param("historyId", "1")
+                                    .param("size", "1")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.result.content[0].commentId").value(1))
+                    .andExpect(jsonPath("$.result.content[1].commentId").value(2))
+                    .andExpect(jsonPath("$.result.isLast").value(false));
+        }
+
+        @Test
+        void 기록에_댓글이_없는_경우_빈_리스트를_응답한다() throws Exception {
+            // given
+            List<CommentListResponse> historyComments = List.of();
+
+            given(commentService.getHistoryComments(1L, null, 1, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(historyComments, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments")
+                                    .param("historyId", "1")
+                                    .param("size", "1")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.result.content").isEmpty())
+                    .andExpect(jsonPath("$.result.isLast").value(true));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "-999", "0"})
+        void 페이지_크기를_0_이하로_설정하면_예외가_발생한다(String pageSize) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments")
+                                    .param("historyId", "1")
+                                    .param("size", pageSize)
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ASCC", "DESCC", "OLDEST", "NEWEST"})
+        void 존재하지_않는_정렬_기준을_입력한_경우_예외가_발생한다(String sort) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments")
+                                    .param("historyId", "1")
+                                    .param("size", "1")
+                                    .param("direction", sort));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
         }
     }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/comment/service/CommentServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/service/CommentServiceTest.java
@@ -3,13 +3,13 @@ package org.clokey.domain.comment.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.Executors;
 import org.clokey.IntegrationTest;
 import org.clokey.comment.entitiy.Comment;
 import org.clokey.comment.entitiy.Reply;
@@ -37,14 +37,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 class CommentServiceTest extends IntegrationTest {
 
     @Autowired TransactionUtil transactionUtil;
 
     @Autowired CommentService commentService;
-    @Autowired CommentRepository commentRepository;
+    @MockitoSpyBean CommentRepository commentRepository;
     @Autowired ReplyRepository replyRepository;
     @Autowired HistoryRepository historyRepository;
     @Autowired MemberRepository memberRepository;
@@ -131,57 +133,27 @@ class CommentServiceTest extends IntegrationTest {
         @Test
         void 댓글_작성_중_히스토리가_삭제되면_예외가_발생한다() throws Exception {
             // given
-            CommentCreateRequest request = new CommentCreateRequest(1L, "댓글 내용");
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
 
-            var barrierBeforeDelete = new CyclicBarrier(2);
-            var barrierAfterDelete = new CyclicBarrier(2);
-            var es = Executors.newFixedThreadPool(2);
+            doAnswer(
+                            invocation -> {
+                                var sqlEx =
+                                        new SQLIntegrityConstraintViolationException(
+                                                "Cannot add or update a child row: a foreign key constraint fails "
+                                                        + "(`testdb`.`comment`, CONSTRAINT `fk_comment_history` FOREIGN KEY (`history_id`) "
+                                                        + "REFERENCES `history` (`id`))",
+                                                "23000",
+                                                1452);
+                                throw new DataIntegrityViolationException(
+                                        "constraint violation", sqlEx);
+                            })
+                    .when(commentRepository)
+                    .save(any(Comment.class));
 
             // when & then
-            var f1 =
-                    es.submit(
-                            () -> {
-                                barrierBeforeDelete.await();
-                                historyRepository.deleteById(1L);
-                                barrierAfterDelete.await();
-
-                                return null;
-                            });
-
-            var f2 =
-                    es.submit(
-                            () -> {
-                                transactionUtil.getResult(
-                                        () -> {
-                                            historyRepository
-                                                    .findById(1L)
-                                                    .orElseThrow(
-                                                            () ->
-                                                                    new BaseCustomException(
-                                                                            HistoryErrorCode
-                                                                                    .HISTORY_NOT_FOUND));
-
-                                            try {
-                                                barrierBeforeDelete.await();
-                                                barrierAfterDelete.await();
-                                            } catch (InterruptedException
-                                                    | BrokenBarrierException e) {
-                                                throw new RuntimeException(e);
-                                            }
-
-                                            assertThatThrownBy(
-                                                            () ->
-                                                                    commentService.createComment(
-                                                                            request))
-                                                    .isInstanceOf(BaseCustomException.class)
-                                                    .hasMessage(
-                                                            HistoryErrorCode.HISTORY_NOT_FOUND
-                                                                    .getMessage());
-
-                                            return null;
-                                        });
-                                return null;
-                            });
+            assertThatThrownBy(() -> commentService.createComment(request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(CommentErrorCode.COMMENT_NOT_FOUND.getMessage());
         }
     }
 
@@ -267,52 +239,28 @@ class CommentServiceTest extends IntegrationTest {
 
         @Test
         void 대댓글을_작성하려는_댓글이_삭제되는_동시성_문제가_발생하면_예외가_발생한다() {
-
             // given
             ReplyCreateRequest request = new ReplyCreateRequest("testReplyContent");
-            var barrierBeforeDelete = new CyclicBarrier(2);
-            var barrierAfterDelete = new CyclicBarrier(2);
-            var es = Executors.newFixedThreadPool(2);
+
+            doAnswer(
+                            invocation -> {
+                                var sqlEx =
+                                        new SQLIntegrityConstraintViolationException(
+                                                "Cannot add or update a child row: a foreign key constraint fails "
+                                                        + "(`testdb`.`reply`, CONSTRAINT `fk_reply_comment` FOREIGN KEY (`comment_id`) "
+                                                        + "REFERENCES `comment` (`id`))",
+                                                "23000",
+                                                1452);
+                                throw new DataIntegrityViolationException(
+                                        "constraint violation", sqlEx);
+                            })
+                    .when(replyRepository)
+                    .save(any(Reply.class));
 
             // when & then
-            var f1 =
-                    es.submit(
-                            () -> {
-                                barrierBeforeDelete.await();
-                                commentRepository.deleteById(1L);
-                                barrierAfterDelete.await();
-                                return null;
-                            });
-
-            var f2 =
-                    es.submit(
-                            () -> {
-                                transactionUtil.getResult(
-                                        () -> {
-                                            Comment comment =
-                                                    commentRepository.findById(1L).orElseThrow();
-
-                                            try {
-                                                barrierBeforeDelete.await();
-                                                barrierAfterDelete.await();
-                                            } catch (InterruptedException
-                                                    | BrokenBarrierException e) {
-                                                throw new RuntimeException(e);
-                                            }
-
-                                            assertThatThrownBy(
-                                                            () ->
-                                                                    commentService.createReply(
-                                                                            1L, request))
-                                                    .isInstanceOf(BaseCustomException.class)
-                                                    .hasMessage(
-                                                            CommentErrorCode.COMMENT_NOT_FOUND
-                                                                    .getMessage());
-
-                                            return null;
-                                        });
-                                return null;
-                            });
+            assertThatThrownBy(() -> commentService.createReply(1L, request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(CommentErrorCode.COMMENT_NOT_FOUND.getMessage());
         }
     }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/comment/service/CommentServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/service/CommentServiceTest.java
@@ -15,6 +15,7 @@ import org.clokey.comment.entitiy.Comment;
 import org.clokey.comment.entitiy.Reply;
 import org.clokey.domain.comment.dto.request.CommentCreateRequest;
 import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
+import org.clokey.domain.comment.dto.response.CommentListResponse;
 import org.clokey.domain.comment.exception.CommentErrorCode;
 import org.clokey.domain.comment.repository.CommentRepository;
 import org.clokey.domain.comment.repository.ReplyRepository;
@@ -24,6 +25,7 @@ import org.clokey.domain.history.repository.HistoryTypeRepository;
 import org.clokey.domain.member.repository.MemberRepository;
 import org.clokey.exception.BaseCustomException;
 import org.clokey.global.FakeAuthContext;
+import org.clokey.global.paging.SortDirection;
 import org.clokey.history.entity.History;
 import org.clokey.history.entity.HistoryType;
 import org.clokey.member.entity.Member;
@@ -32,7 +34,9 @@ import org.clokey.member.enums.MemberStatus;
 import org.clokey.member.enums.OauthProvider;
 import org.clokey.member.enums.RegisterStatus;
 import org.clokey.member.enums.Visibility;
+import org.clokey.response.SliceResponse;
 import org.clokey.util.TransactionUtil;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,7 +51,7 @@ class CommentServiceTest extends IntegrationTest {
 
     @Autowired CommentService commentService;
     @MockitoSpyBean CommentRepository commentRepository;
-    @Autowired ReplyRepository replyRepository;
+    @MockitoSpyBean ReplyRepository replyRepository;
     @Autowired HistoryRepository historyRepository;
     @Autowired MemberRepository memberRepository;
     @Autowired HistoryTypeRepository historyTypeRepository;
@@ -261,6 +265,117 @@ class CommentServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> commentService.createReply(1L, request))
                     .isInstanceOf(BaseCustomException.class)
                     .hasMessage(CommentErrorCode.COMMENT_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class 기록의_댓글_목록을_조회할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            "testEmail1",
+                            "testClokeyId1",
+                            "testNickName1",
+                            OauthInfo.createOauthInfo("testOauthId1", OauthProvider.KAKAO),
+                            MemberStatus.ACTIVE,
+                            RegisterStatus.REGISTERED,
+                            Visibility.PUBLIC);
+            Member member2 =
+                    Member.createMember(
+                            "testEmail2",
+                            "testClokeyId2",
+                            "testNickName2",
+                            OauthInfo.createOauthInfo("testOauthId2", OauthProvider.KAKAO),
+                            MemberStatus.ACTIVE,
+                            RegisterStatus.REGISTERED,
+                            Visibility.PRIVATE);
+
+            memberRepository.saveAll(List.of(member1, member2));
+            given(fakeAuthContext.getCurrentMember()).willReturn(member1);
+
+            HistoryType historyType = HistoryType.createHistoryType("testType");
+            historyTypeRepository.save(historyType);
+
+            History history1 =
+                    History.creatHistory(
+                            LocalDate.of(2025, 1, 1), "testContent1", member1, historyType);
+            History history2 =
+                    History.creatHistory(
+                            LocalDate.of(2025, 1, 1), "testContent2", member2, historyType);
+            History history3 =
+                    History.creatHistory(
+                            LocalDate.of(2025, 1, 2), "testContent3", member1, historyType);
+            historyRepository.saveAll(List.of(history1, history2, history3));
+
+            Comment comment1 = Comment.createComment("testContent1", member1, history1);
+            Comment comment2 = Comment.createComment("testContent2", member2, history1);
+            Comment comment3 = Comment.createComment("testContent3", member2, history1);
+            commentRepository.saveAll(List.of(comment1, comment2, comment3));
+        }
+
+        @Test
+        void 정렬_조건이_ASC이면_commentId를_오름차순으로_조회한다() {
+            // when
+            SliceResponse<CommentListResponse> response =
+                    commentService.getHistoryComments(1L, null, 3, SortDirection.ASC);
+
+            // then
+            assertThat(response.content()).extracting("commentId").containsExactly(1L, 2L, 3L);
+        }
+
+        @Test
+        void 정렬_조건이_DESC면_commentId를_내림차순으로_조회한다() {
+            // when
+            SliceResponse<CommentListResponse> response =
+                    commentService.getHistoryComments(1L, null, 3, SortDirection.DESC);
+
+            // then
+            assertThat(response.content()).extracting("commentId").containsExactly(3L, 2L, 1L);
+        }
+
+        @Test
+        void lastCommentId를_입력하면_다음_comment_부터_조회한다() {
+            // when
+            SliceResponse<CommentListResponse> response =
+                    commentService.getHistoryComments(1L, 1L, 2, SortDirection.ASC);
+
+            // then
+            assertThat(response.content()).extracting("commentId").containsExactly(2L, 3L);
+        }
+
+        @Test
+        void 기록에_댓글이_없는_경우_빈_리스트를_조회한다() {
+            // when
+            SliceResponse<CommentListResponse> response =
+                    commentService.getHistoryComments(3L, null, 3, SortDirection.ASC);
+
+            // when & then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isZero(),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_반환한다() {
+            // when
+            SliceResponse<CommentListResponse> response =
+                    commentService.getHistoryComments(1L, null, 3, SortDirection.ASC);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isEqualTo(3),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 내가_아닌_비공개_계정의_기록의_댓글을_조회하면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(
+                            () -> commentService.getHistoryComments(2L, null, 3, SortDirection.ASC))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(HistoryErrorCode.LIMITED_AUTHORITY.getMessage());
         }
     }
 }

--- a/clokey-common-web/build.gradle
+++ b/clokey-common-web/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation project(':clokey-common')
     api("org.springframework.boot:spring-boot-starter-web")
     api("org.springframework.boot:spring-boot-starter-validation")
+    api('org.springframework.boot:spring-boot-starter-data-jpa')
 
     api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }

--- a/clokey-common-web/src/main/java/org/clokey/response/SliceResponse.java
+++ b/clokey-common-web/src/main/java/org/clokey/response/SliceResponse.java
@@ -1,0 +1,10 @@
+package org.clokey.response;
+
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(List<T> content, boolean isLast) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(slice.getContent(), slice.isLast());
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #28 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 기록의 댓글 목록 조회 API를 구현했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- QueryDSL DTO Projection을 적용했습니다.
- QueryDSL 자체에 의존하지 않기 위해서 @QueryProjection은 사용하지 않았습니다.
- XXXCustomRepository와 XXXCustomImpl 구조를 활용했습니다.
- 쿼리 프로젝션이 조금 복잡한 감이 있는데 3중 조인을 피하기 위해서 쿼리를 두개로 나눴습니다. 대댓글 조회에서는 훨씬 단순한 구조로 구현될 예정입니다.
- Page보다 성능이 좋고 무한 스크롤에 적합한 Slice를 도입했습니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
- 기존에 베리어를 이용해서 동시성 테스트를 하던 것을 ```@MockitoSpyBean```으로 대체해 테스트했습니다.