### PR TITLE
[feat/#30] 대댓글 조회 API 구현

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
 import org.clokey.domain.comment.dto.response.CommentCreateResponse;
 import org.clokey.domain.comment.dto.response.CommentListResponse;
 import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
+import org.clokey.domain.comment.dto.response.ReplyListResponse;
 import org.clokey.domain.comment.service.CommentService;
 import org.clokey.global.annotation.PageSize;
 import org.clokey.global.paging.SortDirection;
@@ -57,6 +58,22 @@ public class CommentController {
                     SortDirection direction) {
         SliceResponse<CommentListResponse> response =
                 commentService.getHistoryComments(historyId, lastCommentId, size, direction);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.OK, response);
+    }
+
+    @GetMapping
+    @Operation(summary = "대댓글 조회", description = "대댓글을 조회합니다")
+    public BaseResponse<SliceResponse<ReplyListResponse>> getReplies(
+            @Parameter(description = "대댓글을 조회중인 댓글의 ID") @RequestParam Long commentId,
+            @Parameter(description = "이전 페이지의 마지막 대댓글 ID (첫 요청 시 생략)")
+                    @RequestParam(required = false)
+                    Long lastReplyId,
+            @Parameter(description = "페이지당 조회할 대댓글 수") @RequestParam @PageSize Integer size,
+            @Parameter(description = "정렬 방향 (ASC: 오래된순, DESC: 최신순)")
+                    @RequestParam(defaultValue = "DESC")
+                    SortDirection direction) {
+        SliceResponse<ReplyListResponse> response =
+                commentService.getCommentReplies(commentId, lastReplyId, size, direction);
         return BaseResponse.onSuccess(GlobalBaseSuccessCode.OK, response);
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/controller/CommentController.java
@@ -61,10 +61,10 @@ public class CommentController {
         return BaseResponse.onSuccess(GlobalBaseSuccessCode.OK, response);
     }
 
-    @GetMapping
+    @GetMapping("/{commentId}/replies")
     @Operation(summary = "대댓글 조회", description = "대댓글을 조회합니다")
     public BaseResponse<SliceResponse<ReplyListResponse>> getReplies(
-            @Parameter(description = "대댓글을 조회중인 댓글의 ID") @RequestParam Long commentId,
+            @PathVariable Long commentId,
             @Parameter(description = "이전 페이지의 마지막 대댓글 ID (첫 요청 시 생략)")
                     @RequestParam(required = false)
                     Long lastReplyId,

--- a/clokey-api/src/main/java/org/clokey/domain/comment/dto/response/ReplyListResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/dto/response/ReplyListResponse.java
@@ -1,0 +1,11 @@
+package org.clokey.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReplyListResponse(
+        @Schema(description = "대댓글 ID", example = "1") Long replyId,
+        @Schema(description = "대댓글 작성자 ID", example = "1") Long memberId,
+        @Schema(description = "대댓글 작성자 닉네임", example = "포테토남") String nickName,
+        @Schema(description = "대댓글 작성자 이미지 주소", example = "https://s3.amazonaws.com/example.jpg")
+                String profileImageUrl,
+        @Schema(description = "대댓글 내용", example = "이 옷 정보 알려주세요!") String content) {}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/repository/ReplyRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/repository/ReplyRepository.java
@@ -3,4 +3,4 @@ package org.clokey.domain.comment.repository;
 import org.clokey.comment.entitiy.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReplyRepository extends JpaRepository<Reply, Long> {}
+public interface ReplyRepository extends JpaRepository<Reply, Long>, ReplyRepositoryCustom {}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/repository/ReplyRepositoryCustom.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/repository/ReplyRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.clokey.domain.comment.repository;
+
+import org.clokey.domain.comment.dto.response.ReplyListResponse;
+import org.clokey.global.paging.SortDirection;
+import org.springframework.data.domain.Slice;
+
+public interface ReplyRepositoryCustom {
+    Slice<ReplyListResponse> findAllByCommentId(
+            Long commentId, Long lastReplyId, int size, SortDirection direction);
+}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/repository/ReplyRepositoryImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/repository/ReplyRepositoryImpl.java
@@ -1,0 +1,67 @@
+package org.clokey.domain.comment.repository;
+
+import static org.clokey.comment.entitiy.QReply.reply;
+import static org.clokey.member.entity.QMember.member;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.clokey.domain.comment.dto.response.ReplyListResponse;
+import org.clokey.global.paging.SortDirection;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReplyRepositoryImpl implements ReplyRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<ReplyListResponse> findAllByCommentId(
+            Long commentId, Long lastReplyId, int size, SortDirection direction) {
+        List<ReplyListResponse> results =
+                queryFactory
+                        .select(
+                                Projections.constructor(
+                                        ReplyListResponse.class,
+                                        reply.id,
+                                        member.id,
+                                        member.nickname,
+                                        member.profileImageUrl,
+                                        reply.content))
+                        .from(reply)
+                        .join(reply.member, member)
+                        .where(
+                                reply.member.id.eq(member.id),
+                                lastReplyIdCondition(lastReplyId, direction))
+                        .orderBy(direction == SortDirection.DESC ? reply.id.desc() : reply.id.asc())
+                        .limit(size + 1)
+                        .fetch();
+
+        return checkLastPage(size, results);
+    }
+
+    private BooleanExpression lastReplyIdCondition(Long replyId, SortDirection direction) {
+        if (replyId == null) {
+            return null;
+        }
+
+        return direction == SortDirection.DESC ? reply.id.lt(replyId) : reply.id.gt(replyId);
+    }
+
+    private <T> Slice<T> checkLastPage(int pageSize, List<T> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/repository/ReplyRepositoryImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/repository/ReplyRepositoryImpl.java
@@ -37,7 +37,7 @@ public class ReplyRepositoryImpl implements ReplyRepositoryCustom {
                         .from(reply)
                         .join(reply.member, member)
                         .where(
-                                reply.member.id.eq(member.id),
+                                reply.comment.id.eq(commentId),
                                 lastReplyIdCondition(lastReplyId, direction))
                         .orderBy(direction == SortDirection.DESC ? reply.id.desc() : reply.id.asc())
                         .limit(size + 1)

--- a/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentService.java
@@ -5,6 +5,7 @@ import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
 import org.clokey.domain.comment.dto.response.CommentCreateResponse;
 import org.clokey.domain.comment.dto.response.CommentListResponse;
 import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
+import org.clokey.domain.comment.dto.response.ReplyListResponse;
 import org.clokey.global.paging.SortDirection;
 import org.clokey.response.SliceResponse;
 
@@ -16,4 +17,7 @@ public interface CommentService {
 
     SliceResponse<CommentListResponse> getHistoryComments(
             Long historyId, Long lastCommentId, int size, SortDirection direction);
+
+    SliceResponse<ReplyListResponse> getCommentReplies(
+            Long commentId, Long lastReplyId, int size, SortDirection direction);
 }

--- a/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentServiceImpl.java
@@ -8,6 +8,7 @@ import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
 import org.clokey.domain.comment.dto.response.CommentCreateResponse;
 import org.clokey.domain.comment.dto.response.CommentListResponse;
 import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
+import org.clokey.domain.comment.dto.response.ReplyListResponse;
 import org.clokey.domain.comment.exception.CommentErrorCode;
 import org.clokey.domain.comment.repository.CommentRepository;
 import org.clokey.domain.comment.repository.ReplyRepository;
@@ -96,6 +97,20 @@ public class CommentServiceImpl implements CommentService {
 
         Slice<CommentListResponse> result =
                 commentRepository.findAllByHistoryId(historyId, lastCommentId, size, direction);
+        return SliceResponse.from(result);
+    }
+
+    @Override
+    public SliceResponse<ReplyListResponse> getCommentReplies(
+            Long commentId, Long lastReplyId, int size, SortDirection direction) {
+        final Member currentMember = fakeAuthContext.getCurrentMember();
+        final Comment comment = getCommentById(commentId);
+
+        validateHistoryAuthority(currentMember, comment.getHistory());
+
+        Slice<ReplyListResponse> result =
+                replyRepository.findAllByCommentId(commentId, lastReplyId, size, direction);
+
         return SliceResponse.from(result);
     }
 

--- a/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
@@ -526,14 +526,14 @@ class CommentControllerTest {
                             new ReplyListResponse(
                                     2L, 1L, "testNickName", "testProfile", "testContent2"));
 
-            given(commentService.getCommentReplies(1L, null, 1, SortDirection.ASC))
+            given(commentService.getCommentReplies(1L, null, 2, SortDirection.ASC))
                     .willReturn(new SliceResponse<>(commentsReplies, false));
 
             // when & then
             ResultActions perform =
                     mockMvc.perform(
                             get("/comments/1/replies")
-                                    .param("size", "1")
+                                    .param("size", "2")
                                     .param("direction", "ASC"));
 
             perform.andExpect(status().isOk())

--- a/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
@@ -411,7 +411,7 @@ class CommentControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.isSuccess").value(false))
                     .andExpect(jsonPath("$.code").value("COMMON400"))
-                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+                    .andExpect(jsonPath("$.message").value("페이지 크기는 0보다 큰 값만 가능합니다."));
         }
 
         @ParameterizedTest
@@ -579,7 +579,7 @@ class CommentControllerTest {
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.isSuccess").value(false))
                     .andExpect(jsonPath("$.code").value("COMMON400"))
-                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+                    .andExpect(jsonPath("$.message").value("페이지 크기는 0보다 큰 값만 가능합니다."));
         }
 
         @ParameterizedTest

--- a/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/controller/CommentControllerTest.java
@@ -14,6 +14,7 @@ import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
 import org.clokey.domain.comment.dto.response.CommentCreateResponse;
 import org.clokey.domain.comment.dto.response.CommentListResponse;
 import org.clokey.domain.comment.dto.response.ReplyCreateResponse;
+import org.clokey.domain.comment.dto.response.ReplyListResponse;
 import org.clokey.domain.comment.exception.CommentErrorCode;
 import org.clokey.domain.comment.service.CommentService;
 import org.clokey.domain.history.exception.HistoryErrorCode;
@@ -423,6 +424,171 @@ class CommentControllerTest {
                                     .param("historyId", "1")
                                     .param("size", "1")
                                     .param("direction", sort));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+        }
+    }
+
+    @Nested
+    class 댓글의_대댓글_목록_조회_요청_시 {
+
+        @Test
+        void 정렬_조건이_ASC이면_replyId를_오름차순으로_응답한다() throws Exception {
+            // given
+            List<ReplyListResponse> commentReplies =
+                    List.of(
+                            new ReplyListResponse(
+                                    1L, 1L, "testNickName", "testProfile", "testContent1"),
+                            new ReplyListResponse(
+                                    2L, 1L, "testNickName", "testProfile", "testContent2"));
+
+            given(commentService.getCommentReplies(1L, null, 2, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(commentReplies, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments/1/replies")
+                                    .param("size", "2")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.result.content[0].replyId").value(1))
+                    .andExpect(jsonPath("$.result.content[1].replyId").value(2))
+                    .andExpect(jsonPath("$.result.isLast").value(true));
+        }
+
+        @Test
+        void 정렬_조건이_DESC이면_replyId를_내림차순으로_응답한다() throws Exception {
+            // given
+            List<ReplyListResponse> commentReplies =
+                    List.of(
+                            new ReplyListResponse(
+                                    2L, 1L, "testNickName", "testProfile", "testContent2"),
+                            new ReplyListResponse(
+                                    1L, 1L, "testNickName", "testProfile", "testContent1"));
+
+            given(commentService.getCommentReplies(1L, null, 2, SortDirection.DESC))
+                    .willReturn(new SliceResponse<>(commentReplies, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments/1/replies")
+                                    .param("size", "2")
+                                    .param("direction", "DESC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.result.content[0].replyId").value(2))
+                    .andExpect(jsonPath("$.result.content[1].replyId").value(1))
+                    .andExpect(jsonPath("$.result.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_응답한다() throws Exception {
+            // given
+            List<ReplyListResponse> commentReplies =
+                    List.of(
+                            new ReplyListResponse(
+                                    2L, 1L, "testNickName", "testProfile", "testContent2"));
+
+            given(commentService.getCommentReplies(1L, null, 1, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(commentReplies, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments/1/replies")
+                                    .param("size", "1")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.result.content[0].replyId").value(2))
+                    .andExpect(jsonPath("$.result.isLast").value(true));
+        }
+
+        @Test
+        void 마지막_페이지가_아닌_경우_isLast를_false로_응답한다() throws Exception {
+            // given
+            List<ReplyListResponse> commentsReplies =
+                    List.of(
+                            new ReplyListResponse(
+                                    1L, 1L, "testNickName", "testProfile", "testContent1"),
+                            new ReplyListResponse(
+                                    2L, 1L, "testNickName", "testProfile", "testContent2"));
+
+            given(commentService.getCommentReplies(1L, null, 1, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(commentsReplies, false));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments/1/replies")
+                                    .param("size", "1")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.result.content[0].replyId").value(1))
+                    .andExpect(jsonPath("$.result.content[1].replyId").value(2))
+                    .andExpect(jsonPath("$.result.isLast").value(false));
+        }
+
+        @Test
+        void 댓글에_대댓글이_없는_경우_빈_리스트를_응답한다() throws Exception {
+            // given
+            List<ReplyListResponse> commentReplies = List.of();
+
+            given(commentService.getCommentReplies(1L, null, 1, SortDirection.ASC))
+                    .willReturn(new SliceResponse<>(commentReplies, true));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments/1/replies")
+                                    .param("size", "1")
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.result.content").isEmpty())
+                    .andExpect(jsonPath("$.result.isLast").value(true));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "-999", "0"})
+        void 페이지_크기를_0_이하로_설정하면_예외가_발생한다(String pageSize) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments/1/replies")
+                                    .param("size", pageSize)
+                                    .param("direction", "ASC"));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ASCC", "DESCC", "OLDEST", "NEWEST"})
+        void 존재하지_않는_정렬_기준을_입력한_경우_예외가_발생한다(String sort) throws Exception {
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/comments/1/replies").param("size", "1").param("direction", sort));
 
             perform.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.isSuccess").value(false))

--- a/clokey-api/src/test/java/org/clokey/domain/comment/service/CommentServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/comment/service/CommentServiceTest.java
@@ -16,6 +16,7 @@ import org.clokey.comment.entitiy.Reply;
 import org.clokey.domain.comment.dto.request.CommentCreateRequest;
 import org.clokey.domain.comment.dto.request.ReplyCreateRequest;
 import org.clokey.domain.comment.dto.response.CommentListResponse;
+import org.clokey.domain.comment.dto.response.ReplyListResponse;
 import org.clokey.domain.comment.exception.CommentErrorCode;
 import org.clokey.domain.comment.repository.CommentRepository;
 import org.clokey.domain.comment.repository.ReplyRepository;
@@ -370,10 +371,145 @@ class CommentServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 존재하지_않는_기록을_입력하면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    commentService.getHistoryComments(
+                                            999L, null, 3, SortDirection.ASC))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(HistoryErrorCode.HISTORY_NOT_FOUND.getMessage());
+        }
+
+        @Test
         void 내가_아닌_비공개_계정의_기록의_댓글을_조회하면_예외가_발생한다() {
             // when & then
             assertThatThrownBy(
                             () -> commentService.getHistoryComments(2L, null, 3, SortDirection.ASC))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(HistoryErrorCode.LIMITED_AUTHORITY.getMessage());
+        }
+    }
+
+    @Nested
+    class 댓글의_대댓글_목록을_조회할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            "testEmail1",
+                            "testClokeyId1",
+                            "testNickName1",
+                            OauthInfo.createOauthInfo("testOauthId1", OauthProvider.KAKAO),
+                            MemberStatus.ACTIVE,
+                            RegisterStatus.REGISTERED,
+                            Visibility.PUBLIC);
+            Member member2 =
+                    Member.createMember(
+                            "testEmail2",
+                            "testClokeyId2",
+                            "testNickName2",
+                            OauthInfo.createOauthInfo("testOauthId2", OauthProvider.KAKAO),
+                            MemberStatus.ACTIVE,
+                            RegisterStatus.REGISTERED,
+                            Visibility.PRIVATE);
+
+            memberRepository.saveAll(List.of(member1, member2));
+            given(fakeAuthContext.getCurrentMember()).willReturn(member1);
+
+            HistoryType historyType = HistoryType.createHistoryType("testType");
+            historyTypeRepository.save(historyType);
+
+            History history1 =
+                    History.creatHistory(
+                            LocalDate.of(2025, 1, 1), "testContent1", member1, historyType);
+            History history2 =
+                    History.creatHistory(
+                            LocalDate.of(2025, 1, 1), "testContent2", member2, historyType);
+            historyRepository.saveAll(List.of(history1, history2));
+
+            Comment comment1 = Comment.createComment("testContent1", member1, history1);
+            Comment comment2 = Comment.createComment("testContent2", member2, history2);
+            Comment comment3 = Comment.createComment("testContent3", member1, history1);
+            commentRepository.saveAll(List.of(comment1, comment2, comment3));
+
+            Reply reply1 = Reply.createReply("testContent1", member1, comment1);
+            Reply reply2 = Reply.createReply("testContent2", member2, comment1);
+            Reply reply3 = Reply.createReply("testContetn3", member2, comment2);
+            replyRepository.saveAll(List.of(reply1, reply2, reply3));
+        }
+
+        @Test
+        void 정렬_조건이_ASC이면_replyId를_오름차순으로_조회한다() {
+            // when
+            SliceResponse<ReplyListResponse> response =
+                    commentService.getCommentReplies(1L, null, 2, SortDirection.ASC);
+
+            // then
+            assertThat(response.content()).extracting("replyId").containsExactly(1L, 2L);
+        }
+
+        @Test
+        void 정렬_조건이_DESC면_replyId를_내림차순으로_조회한다() {
+            // when
+            SliceResponse<ReplyListResponse> response =
+                    commentService.getCommentReplies(1L, null, 2, SortDirection.DESC);
+
+            // then
+            assertThat(response.content()).extracting("replyId").containsExactly(2L, 1L);
+        }
+
+        @Test
+        void lastReplyId를_입력하면_다음_reply_부터_조회한다() {
+            // when
+            SliceResponse<ReplyListResponse> response =
+                    commentService.getCommentReplies(1L, 1L, 2, SortDirection.ASC);
+
+            // then
+            assertThat(response.content()).extracting("replyId").containsExactly(2L);
+        }
+
+        @Test
+        void 댓글에_대댓글이_없는_경우_빈_리스트를_조회한다() {
+            // when
+            SliceResponse<ReplyListResponse> response =
+                    commentService.getCommentReplies(3L, null, 3, SortDirection.ASC);
+
+            // when & then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isZero(),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 마지막_페이지인_경우_isLast를_true로_반환한다() {
+            // when
+            SliceResponse<ReplyListResponse> response =
+                    commentService.getCommentReplies(1L, null, 2, SortDirection.ASC);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content().size()).isEqualTo(2),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        void 존재하지_않는_댓글을_입력하면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    commentService.getCommentReplies(
+                                            999L, null, 3, SortDirection.ASC))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(CommentErrorCode.COMMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 내가_아닌_비공개_계정의_기록의_대댓글을_조회하면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(
+                            () -> commentService.getCommentReplies(2L, null, 3, SortDirection.ASC))
                     .isInstanceOf(BaseCustomException.class)
                     .hasMessage(HistoryErrorCode.LIMITED_AUTHORITY.getMessage());
         }

--- a/clokey-common-web/src/main/java/org/clokey/exception/GlobalExceptionAdvice.java
+++ b/clokey-common-web/src/main/java/org/clokey/exception/GlobalExceptionAdvice.java
@@ -50,13 +50,9 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
                 e.getConstraintViolations().stream()
                         .map(constraintViolation -> constraintViolation.getMessage())
                         .findFirst()
-                        .orElse("COMMON400");
+                        .orElse("잘못된 요청입니다");
 
-        GlobalBaseErrorCode errorCode =
-                GlobalBaseErrorCode.findByCode(errorMessage)
-                        .orElse(GlobalBaseErrorCode.BAD_REQUEST);
-
-        return handleExceptionInternalConstraint(e, errorCode, HttpHeaders.EMPTY, request);
+        return handleExceptionInternalConstraint(e, errorMessage, HttpHeaders.EMPTY, request);
     }
 
     @Override
@@ -165,14 +161,17 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
     }
 
     private ResponseEntity<Object> handleExceptionInternalConstraint(
-            Exception e,
-            GlobalBaseErrorCode errorCommonStatus,
-            HttpHeaders headers,
-            WebRequest request) {
+            Exception e, String errorMessage, HttpHeaders headers, WebRequest request) {
 
-        BaseResponse<Object> body = BaseResponse.onFailure(errorCommonStatus, null);
+        BaseResponse<Object> body =
+                BaseResponse.onFailure(
+                        GlobalBaseErrorCode.BAD_REQUEST.getCode(), errorMessage, null);
         return super.handleExceptionInternal(
-                e, body, headers, HttpStatus.valueOf(errorCommonStatus.getStatus()), request);
+                e,
+                body,
+                headers,
+                HttpStatus.valueOf(GlobalBaseErrorCode.BAD_REQUEST.getStatus()),
+                request);
     }
 
     private ResponseEntity<Object> handleExceptionInternalMessage(


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #30 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 대댓글 조회 API를 작성했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 대댓글 조회 API를 작성했습니다.
- 구조는 댓글 조회 API와 동일합니다.
- 댓글 조회 API는 복잡한 쿼리 잡업이 있었는데, 일반적으로 하나의 쿼리만 작성하는 경우 지금과 같은 구조를 가지게 됩니다!
- 페이징시 참고하세요 ~