### PR TITLE
[feat/#27] id duplicate check

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/member/controller/MemberController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/controller/MemberController.java
@@ -33,6 +33,7 @@ public class MemberController {
     public BaseResponse<Void> checkID(
             @PathVariable("clokey_id") @NotBlank String clokeyId) { // 클로키 아이디를 PathVariable로 받음
 
-        memberService.clokeyIdUsingCheck(clokeyId);
+        memberService.checkClokeyIdUsing(clokeyId);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.NO_CONTENT, null);
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/member/controller/MemberController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/controller/MemberController.java
@@ -1,0 +1,41 @@
+package org.clokey.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.clokey.code.GlobalBaseSuccessCode;
+import org.clokey.domain.member.dto.request.ProfileRequest;
+import org.clokey.domain.member.dto.response.ProfileResponse;
+import org.clokey.domain.member.service.MemberService;
+import org.clokey.response.BaseResponse;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+@Tag(name = "3. 멤버 API", description = "멤버 관련 API입니다.")
+@Validated
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PatchMapping
+    @Operation(summary = "프로필 수정", description = "프로필을 수정/추가 합니다.")
+    public BaseResponse<ProfileResponse> updateProfile(@Valid @RequestBody ProfileRequest request) {
+        ProfileResponse response = memberService.updateProfile(request);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.CREATED, response);
+    }
+
+    @GetMapping("/{clokey_id}/check")
+    @Operation(summary = "아이디 중복확인", description = "클로키아이디 중복을 확인합니다.")
+    public BaseResponse<Void> checkID(
+            @PathVariable("clokey_id") @NotBlank String clokeyId) { // 클로키 아이디를 PathVariable로 받음
+
+        memberService.clokeyIdUsingCheck(clokeyId);
+
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.NO_CONTENT, null);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/member/exception/MemberErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/exception/MemberErrorCode.java
@@ -1,0 +1,23 @@
+package org.clokey.domain.member.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.clokey.dto.ErrorReasonDto;
+import org.clokey.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements BaseErrorCode {
+    BANNED_MEMBER_TO_PUBLIC(404, "MEMBER_4013", "신고당한 회원은 공개로 전환할 수 없습니다."),
+    DUPLICATE_CLOKEY_ID(404, "MEMBER_4005", "중복된 클로키 아이디입니다."),
+    ;
+
+    private int status;
+    private String code;
+    private String message;
+
+    @Override
+    public ErrorReasonDto getErrorReason() {
+        return org.clokey.dto.ErrorReasonDto.of(status, code, message);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/member/repository/MemberRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/repository/MemberRepository.java
@@ -3,4 +3,7 @@ package org.clokey.domain.member.repository;
 import org.clokey.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {}
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByClokeyId(String clokeyId);
+}

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberService.java
@@ -1,0 +1,11 @@
+package org.clokey.domain.member.service;
+
+import org.clokey.domain.member.dto.request.ProfileRequest;
+import org.clokey.domain.member.dto.response.ProfileResponse;
+
+public interface MemberService {
+
+    ProfileResponse updateProfile(ProfileRequest request);
+
+    void clokeyIdUsingCheck(String clokeyId);
+}

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberService.java
@@ -6,5 +6,5 @@ public interface MemberService {
 
     void updateProfile(ProfileUpdateRequest request);
 
-    void clokeyIdUsingCheck(String clokeyId);
+    void checkClokeyIdUsing(String clokeyId);
 }

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
@@ -1,0 +1,97 @@
+package org.clokey.domain.member.service;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import lombok.RequiredArgsConstructor;
+import org.clokey.domain.member.dto.request.ProfileRequest;
+import org.clokey.domain.member.dto.response.ProfileResponse;
+import org.clokey.domain.member.exception.MemberErrorCode;
+import org.clokey.domain.member.repository.MemberRepository;
+import org.clokey.exception.BaseCustomException;
+import org.clokey.global.FakeAuthContext;
+import org.clokey.member.entity.Member;
+import org.clokey.member.enums.MemberStatus;
+import org.clokey.member.enums.RegisterStatus;
+import org.clokey.member.enums.Visibility;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberServiceImpl implements MemberService {
+
+    private final FakeAuthContext fakeAuthContext;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public ProfileResponse updateProfile(ProfileRequest request) {
+        // 사용자 확인
+        final Member member = fakeAuthContext.getCurrentMember();
+
+        // 사용자 상태 체크 및 유효성 검증
+        validateVisualizeBannedMember(member, request);
+
+        String profileImageUrl =
+                hasText(request.profileImageUrl())
+                        ? request.profileImageUrl()
+                        : member.getProfileImageUrl();
+
+        String profileBackImageUrl =
+                hasText(request.profileBackImageUrl())
+                        ? request.profileBackImageUrl()
+                        : member.getProfileBackImageUrl();
+
+        // 프로필 업데이트
+        member.profileUpdate(
+                request.nickname(),
+                request.clokeyId(),
+                profileImageUrl,
+                profileBackImageUrl,
+                request.bio(),
+                request.visibility());
+
+        // 등록 상태 업데이트 (약관 동의가 완료된 경우)
+        if (member.getRegisterStatus() != RegisterStatus.REGISTERED) {
+            member.updateRegisterStatus(RegisterStatus.REGISTERED);
+        }
+
+        // 저장
+        Member updatedMember = memberRepository.save(member);
+
+        // Elasticsearch 동기화였던 부분 삭제
+
+        // 응답 DTO 반환
+        return ProfileResponse.from(updatedMember);
+    }
+
+    private void validateVisualizeBannedMember(Member member, ProfileRequest request) {
+        boolean banned = member.getMemberStatus().equals(MemberStatus.BANNED);
+        boolean changeToPublic = request.visibility().equals(Visibility.PUBLIC);
+        if (banned && changeToPublic) {
+            throw new BaseCustomException(MemberErrorCode.BANNED_MEMBER_TO_PUBLIC);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void clokeyIdUsingCheck(String clokeyId) {
+        // 현재 로그인한 사용자의 clokeyId 가져오기
+        final Member member = fakeAuthContext.getCurrentMember();
+        String myClokeyId = member.getClokeyId();
+
+        // 1️⃣ 내 아이디가 없으면 입력한 아이디가 중복인지 검사
+        if (myClokeyId == null) {
+            if (memberRepository.existsByClokeyId(clokeyId)) {
+                throw new BaseCustomException(MemberErrorCode.DUPLICATE_CLOKEY_ID);
+            }
+            return;
+        }
+
+        // 2️⃣ 내 아이디가 존재하면, 내가 입력한 아이디가 기존 내 아이디와 다를 때만 중복 검사
+        if (!clokeyId.equals(myClokeyId) && memberRepository.existsByClokeyId(clokeyId)) {
+            throw new BaseCustomException(MemberErrorCode.DUPLICATE_CLOKEY_ID);
+        }
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
@@ -72,20 +72,11 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional(readOnly = true)
-    public void clokeyIdUsingCheck(String clokeyId) {
+    public void checkClokeyIdUsing(String clokeyId) {
         // 현재 로그인한 사용자의 clokeyId 가져오기
         final Member member = fakeAuthContext.getCurrentMember();
         String myClokeyId = member.getClokeyId();
 
-        // 1️⃣ 내 아이디가 없으면 입력한 아이디가 중복인지 검사
-        if (myClokeyId == null) {
-            if (memberRepository.existsByClokeyId(clokeyId)) {
-                throw new BaseCustomException(MemberErrorCode.DUPLICATE_CLOKEY_ID);
-            }
-            return;
-        }
-
-        // 2️⃣ 내 아이디가 존재하면, 내가 입력한 아이디가 기존 내 아이디와 다를 때만 중복 검사
         if (!clokeyId.equals(myClokeyId) && memberRepository.existsByClokeyId(clokeyId)) {
             throw new BaseCustomException(MemberErrorCode.DUPLICATE_CLOKEY_ID);
         }

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
@@ -24,14 +24,14 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public void updateProfile(ProfileUpdateRequest request) {
-        // 사용자 확인
+
         Long memberId = fakeAuthContext.getCurrentMember().getId();
         final Member member =
                 memberRepository
                         .findById(memberId)
                         .orElseThrow(
                                 () -> new BaseCustomException(MemberErrorCode.MEMBER_NOT_FOUND));
-        // 사용자 상태 체크 및 유효성 검증
+
         validateVisualizeBannedMember(member, request);
 
         String profileImageUrl;
@@ -50,7 +50,6 @@ public class MemberServiceImpl implements MemberService {
             profileBackImageUrl = request.profileBackImageUrl();
         }
 
-        // 프로필 업데이트
         member.updateProfile(
                 request.nickname(),
                 request.clokeyId(),
@@ -73,7 +72,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional(readOnly = true)
     public void checkClokeyIdUsing(String clokeyId) {
-        // 현재 로그인한 사용자의 clokeyId 가져오기
+
         final Member member = fakeAuthContext.getCurrentMember();
         String myClokeyId = member.getClokeyId();
 

--- a/clokey-api/src/test/java/org/clokey/domain/member/controller/MemberControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/member/controller/MemberControllerTest.java
@@ -2,6 +2,7 @@ package org.clokey.domain.member.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -150,6 +151,45 @@ class MemberControllerTest {
                     .andExpect(jsonPath("$.code").value("COMMON400"))
                     .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
                     .andExpect(jsonPath("$.result.bio").value("바이오는 100자를 넘길 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 아이디_중복확인_요청_시 {
+
+        @Test
+        void 사용가능하면_성공코드를_반환한다() throws Exception {
+            // given
+            String clokeyId = "availableId";
+            willDoNothing().given(memberService).checkClokeyIdUsing(clokeyId);
+
+            // when
+            ResultActions perform = mockMvc.perform(get("/users/{clokey_id}/check", clokeyId));
+
+            // then
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON204"))
+                    .andExpect(jsonPath("$.message").value("요청 성공 및 반환값 없음"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {" "})
+        void 클로키아이디가_공백이면_예외가_발생한다(String clokeyId) throws Exception {
+            mockMvc.perform(get("/users/{clokey_id}/check", clokeyId))
+                    .andExpect(status().is4xxClientError()); // JSON 기대 대신 상태 코드만 체크
+        }
+
+        @Test
+        void 클로키아이디가_빈문자열이면_예외가_발생한다() throws Exception {
+            mockMvc.perform(get("/users/{clokey_id}/check", "")) // /users//check
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void 클로키아이디가_null이면_예외가_발생한다() throws Exception {
+            mockMvc.perform(get("/users/{clokey_id}/check", (Object) null))
+                    .andExpect(status().is4xxClientError()); // 예외 대신 상태 코드 체크
         }
     }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/member/controller/MemberControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/member/controller/MemberControllerTest.java
@@ -128,7 +128,7 @@ class MemberControllerTest {
         @Test
         void 바이오가_100자를_초과하면_예외가_발생한다() throws Exception {
             // given
-            String longBio = "a".repeat(101); // 101자
+            String longBio = "a".repeat(101);
             ProfileUpdateRequest request =
                     new ProfileUpdateRequest(
                             "testNickname",
@@ -177,19 +177,18 @@ class MemberControllerTest {
         @ValueSource(strings = {" "})
         void 클로키아이디가_공백이면_예외가_발생한다(String clokeyId) throws Exception {
             mockMvc.perform(get("/users/{clokey_id}/check", clokeyId))
-                    .andExpect(status().is4xxClientError()); // JSON 기대 대신 상태 코드만 체크
+                    .andExpect(status().is4xxClientError());
         }
 
         @Test
         void 클로키아이디가_빈문자열이면_예외가_발생한다() throws Exception {
-            mockMvc.perform(get("/users/{clokey_id}/check", "")) // /users//check
-                    .andExpect(status().isNotFound());
+            mockMvc.perform(get("/users/{clokey_id}/check", "")).andExpect(status().isNotFound());
         }
 
         @Test
         void 클로키아이디가_null이면_예외가_발생한다() throws Exception {
             mockMvc.perform(get("/users/{clokey_id}/check", (Object) null))
-                    .andExpect(status().is4xxClientError()); // 예외 대신 상태 코드 체크
+                    .andExpect(status().is4xxClientError());
         }
     }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/member/service/MemberServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/member/service/MemberServiceTest.java
@@ -34,7 +34,6 @@ class MemberServiceTest extends IntegrationTest {
 
         @BeforeEach
         void setUp() {
-            // 기본 멤버 생성
             Member member =
                     Member.createMember(
                             "testEmail",
@@ -45,7 +44,6 @@ class MemberServiceTest extends IntegrationTest {
                             RegisterStatus.REGISTERED,
                             Visibility.PRIVATE);
 
-            // 기존 프로필 값 세팅
             member.updateProfile(
                     "oldNickname",
                     "oldClokeyId",
@@ -101,9 +99,8 @@ class MemberServiceTest extends IntegrationTest {
                             "testClokeyId",
                             "testBio",
                             Visibility.PRIVATE,
-                            null, // profileImageUrl 삭제
-                            " " // profileBackImageUrl 삭제
-                            );
+                            null,
+                            " ");
 
             // when
             memberService.updateProfile(request);
@@ -168,8 +165,9 @@ class MemberServiceTest extends IntegrationTest {
 
         @Test
         void 내_아이디와_같은_ID를_요청하면_성공한다() {
-            // given: 내 clokeyId = meId
-            Member me = member("myId");
+            // given
+            member("myId");
+            Member me = memberRepository.findById(1L).orElseThrow();
             given(fakeAuthContext.getCurrentMember()).willReturn(me);
 
             // when& then
@@ -179,10 +177,10 @@ class MemberServiceTest extends IntegrationTest {
         @Test
         void 다른_사람이_쓰는_ID를_요청하면_예외가_발생한다() {
             // given
-            Member me = member("myId");
+            member("myId");
+            Member me = memberRepository.findById(1L).orElseThrow();
             given(fakeAuthContext.getCurrentMember()).willReturn(me);
 
-            // 다른 사용자가 이미 사용 중인 ID
             member("usedId");
 
             // when & then
@@ -194,7 +192,8 @@ class MemberServiceTest extends IntegrationTest {
         @Test
         void 다른_사람이_쓰지_않는_ID를_요청하면_성공한다() {
             // given
-            Member me = member("myId");
+            member("myId");
+            Member me = memberRepository.findById(1L).orElseThrow();
             given(fakeAuthContext.getCurrentMember()).willReturn(me);
 
             // when

--- a/clokey-api/src/test/java/org/clokey/domain/member/service/MemberServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/member/service/MemberServiceTest.java
@@ -149,4 +149,59 @@ class MemberServiceTest extends IntegrationTest {
                     .hasMessage(MemberErrorCode.BANNED_MEMBER_TO_PUBLIC.getMessage());
         }
     }
+
+    @Nested
+    class 아이디_중복_확인_시 {
+
+        private Member member(String clokeyId) {
+            Member m =
+                    Member.createMember(
+                            "testEmail",
+                            clokeyId,
+                            "testNickname",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO),
+                            MemberStatus.ACTIVE,
+                            RegisterStatus.REGISTERED,
+                            Visibility.PRIVATE);
+            return memberRepository.save(m);
+        }
+
+        @Test
+        void 내_아이디와_같은_ID를_요청하면_성공한다() {
+            // given: 내 clokeyId = meId
+            Member me = member("myId");
+            given(fakeAuthContext.getCurrentMember()).willReturn(me);
+
+            // when& then
+            memberService.checkClokeyIdUsing("myId");
+        }
+
+        @Test
+        void 다른_사람이_쓰는_ID를_요청하면_예외가_발생한다() {
+            // given
+            Member me = member("myId");
+            given(fakeAuthContext.getCurrentMember()).willReturn(me);
+
+            // 다른 사용자가 이미 사용 중인 ID
+            member("usedId");
+
+            // when & then
+            assertThatThrownBy(() -> memberService.checkClokeyIdUsing("usedId"))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(MemberErrorCode.DUPLICATE_CLOKEY_ID.getMessage());
+        }
+
+        @Test
+        void 다른_사람이_쓰지_않는_ID를_요청하면_성공한다() {
+            // given
+            Member me = member("myId");
+            given(fakeAuthContext.getCurrentMember()).willReturn(me);
+
+            // when
+            memberService.checkClokeyIdUsing("availableId");
+
+            // then
+            assertThat(memberRepository.existsByClokeyId("availableId")).isFalse();
+        }
+    }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #27 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- id 중복확인 api를 구현했습니다
- 테스트코드를 추가했습니다

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 
-

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
클로키아이디가 공백인 3가지경우 (공백, 빈문자열, 널) 일때마다 다른 종류의 에러가 떠서 한번에 처리가 어려운 것 같더라고요. 그래서 케이스를 나누었습니다. (컨트롤러테스트) 이 부분에 대해 의견 있으시면 말씀주세요!
