### PR TITLE
[feat/#39] 약관 동의 API

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/term/controller/TermController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/controller/TermController.java
@@ -1,0 +1,30 @@
+package org.clokey.domain.term.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.clokey.code.GlobalBaseSuccessCode;
+import org.clokey.domain.term.dto.TermAgreeRequest;
+import org.clokey.domain.term.service.TermService;
+import org.clokey.response.BaseResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/terms")
+@RequiredArgsConstructor
+@Tag(name = "2. 약관 API", description = "약관 관련 API입니다.")
+public class TermController {
+
+    private final TermService termService;
+
+    @PostMapping
+    @Operation(summary = "약관 동의", description = "약관 동의 정보를 설정합니다.")
+    public BaseResponse<Void> agreeTerm(@Valid @RequestBody TermAgreeRequest request) {
+        termService.agreeTerm(request);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.NO_CONTENT, null);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/term/dto/TermAgreeRequest.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/dto/TermAgreeRequest.java
@@ -1,0 +1,20 @@
+package org.clokey.domain.term.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record TermAgreeRequest(
+        @NotNull(message = "Device Token은 비워둘 수 없습니다.")
+                @Schema(description = "기기를 식별할 수 있는 Device Token")
+                String deviceToken,
+        @NotEmpty(message = "약관 동의 정보는 비워둘 수 없습니다.") @Valid @Schema(description = "약관 동의 정보 리스트")
+                List<Payload> payloads) {
+    public record Payload(
+            @NotNull(message = "약관 ID는 비워둘 수 없습니다.") @Schema(description = "약관 ID") Long termId,
+            @NotNull(message = "약관 동의 여부는 비워둘 수 없습니다.")
+                    @Schema(description = "약관 동의 여부", example = "true")
+                    Boolean agreed) {}
+}

--- a/clokey-api/src/main/java/org/clokey/domain/term/dto/TermAgreeRequest.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/dto/TermAgreeRequest.java
@@ -2,12 +2,13 @@ package org.clokey.domain.term.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record TermAgreeRequest(
-        @NotNull(message = "Device Token은 비워둘 수 없습니다.")
+        @NotBlank(message = "Device Token은 비워둘 수 없습니다.")
                 @Schema(description = "기기를 식별할 수 있는 Device Token")
                 String deviceToken,
         @NotEmpty(message = "약관 동의 정보는 비워둘 수 없습니다.") @Valid @Schema(description = "약관 동의 정보 리스트")

--- a/clokey-api/src/main/java/org/clokey/domain/term/enums/TermInfo.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/enums/TermInfo.java
@@ -1,0 +1,30 @@
+package org.clokey.domain.term.enums;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TermInfo {
+    SERVICE_USE(1L, false),
+    PRIVATE_POLICY(2L, false),
+    LOCATION_BASED_SERVICE(3L, false),
+    MARKETING_INFO_RECEIVE(4L, true),
+    PUSH_NOTIFICATION_RECEIVE(5L, true);
+
+    private Long id;
+    private boolean optional;
+
+    public static List<Long> getNonOptionalIds() {
+        return Arrays.stream(values())
+                .filter(term -> !term.isOptional())
+                .map(TermInfo::getId)
+                .toList();
+    }
+
+    public static List<Long> getAllIds() {
+        return Arrays.stream(values()).map(TermInfo::getId).toList();
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/term/exception/TermErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/exception/TermErrorCode.java
@@ -1,0 +1,24 @@
+package org.clokey.domain.term.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.clokey.dto.ErrorReasonDto;
+import org.clokey.exception.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum TermErrorCode implements BaseErrorCode {
+    TERMS_MISMATCH(400, "TERM_4001", "응답한 약관 ID들이 DB에 존재하는 약관ID들과 일치하지 않습니다."),
+    NON_OPTIONAL_NOT_AGREED(400, "TERM_4002", "필수 약관에 동의하지 않았습니다."),
+
+    TERM_NOT_FOUND(404, "TERM_4041", "약관이 존재하지 않습니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getErrorReason() {
+        return ErrorReasonDto.of(status, code, message);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/term/service/TermService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/service/TermService.java
@@ -1,0 +1,8 @@
+package org.clokey.domain.term.service;
+
+import org.clokey.domain.term.dto.TermAgreeRequest;
+
+public interface TermService {
+
+    void agreeTerm(TermAgreeRequest request);
+}

--- a/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
@@ -24,7 +24,7 @@ public class TermServiceImpl implements TermService {
 
     private final MemberUtil memberUtil;
 
-    private final TermRepository repository;
+    private final TermRepository termRepository;
     private final MemberTermRepository memberTermRepository;
 
     @Override
@@ -42,7 +42,7 @@ public class TermServiceImpl implements TermService {
                         .map(
                                 payload -> {
                                     Term term =
-                                            repository
+                                            termRepository
                                                     .findById(payload.termId())
                                                     .orElseThrow(
                                                             () ->

--- a/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
@@ -1,0 +1,88 @@
+package org.clokey.domain.term.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.clokey.domain.term.dto.TermAgreeRequest;
+import org.clokey.domain.term.enums.TermInfo;
+import org.clokey.domain.term.exception.TermErrorCode;
+import org.clokey.domain.term.repository.MemberTermRepository;
+import org.clokey.domain.term.repository.TermRepository;
+import org.clokey.exception.BaseCustomException;
+import org.clokey.global.util.MemberUtil;
+import org.clokey.member.entity.Member;
+import org.clokey.term.entity.MemberTerm;
+import org.clokey.term.entity.Term;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TermServiceImpl implements TermService {
+
+    private final MemberUtil memberUtil;
+
+    private final TermRepository repository;
+    private final MemberTermRepository memberTermRepository;
+
+    @Override
+    @Transactional
+    public void agreeTerm(TermAgreeRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        validateAllTermContained(request);
+        validateAgreedNonOptionalTerms(request);
+
+        currentMember.updateDeviceToken(request.deviceToken());
+
+        List<MemberTerm> memberTerms =
+                request.payloads().stream()
+                        .map(
+                                payload -> {
+                                    Term term =
+                                            repository
+                                                    .findById(payload.termId())
+                                                    .orElseThrow(
+                                                            () ->
+                                                                    new BaseCustomException(
+                                                                            TermErrorCode
+                                                                                    .TERM_NOT_FOUND));
+
+                                    return MemberTerm.createMemberTerm(
+                                            currentMember, term, payload.agreed());
+                                })
+                        .toList();
+
+        memberTermRepository.saveAll(memberTerms);
+    }
+
+    private void validateAllTermContained(TermAgreeRequest request) {
+        List<Long> allTermIds = TermInfo.getAllIds();
+
+        List<Long> requestTermIds =
+                request.payloads().stream().map(TermAgreeRequest.Payload::termId).toList();
+
+        Set<Long> allSet = new HashSet<>(allTermIds);
+        Set<Long> requestSet = new HashSet<>(requestTermIds);
+
+        if (!allSet.equals(requestSet)) {
+            throw new BaseCustomException(TermErrorCode.TERMS_MISMATCH);
+        }
+    }
+
+    private void validateAgreedNonOptionalTerms(TermAgreeRequest request) {
+        List<Long> requiredIds = TermInfo.getNonOptionalIds();
+
+        List<Long> agreedIds =
+                request.payloads().stream()
+                        .filter(TermAgreeRequest.Payload::agreed)
+                        .map(TermAgreeRequest.Payload::termId)
+                        .toList();
+
+        if (!agreedIds.containsAll(requiredIds)) {
+            throw new BaseCustomException(TermErrorCode.NON_OPTIONAL_NOT_AGREED);
+        }
+    }
+}

--- a/clokey-api/src/test/java/org/clokey/domain/auth/service/AuthServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/auth/service/AuthServiceTest.java
@@ -74,7 +74,7 @@ class AuthServiceTest extends IntegrationTest {
             Member member = memberRepository.findById(1L).orElseThrow();
             Term term = termRepository.findById(1L).orElseThrow();
 
-            MemberTerm memberTerm = MemberTerm.createMemberTerm(member, term);
+            MemberTerm memberTerm = MemberTerm.createMemberTerm(member, term, true);
             memberTermRepository.save(memberTerm);
 
             // when

--- a/clokey-api/src/test/java/org/clokey/domain/term/controller/TermControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/term/controller/TermControllerTest.java
@@ -1,0 +1,151 @@
+package org.clokey.domain.term.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.clokey.domain.term.dto.TermAgreeRequest;
+import org.clokey.domain.term.service.TermService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(TermController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TermControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private TermService termService;
+
+    @Nested
+    class 약관_동의_요청_시 {
+
+        @Test
+        void 유효한_요청이면_약관을_동의하고_NO_CONTENT를_반환한다() throws Exception {
+            // given
+            TermAgreeRequest request =
+                    new TermAgreeRequest(
+                            "testDeviceToken",
+                            List.of(
+                                    new TermAgreeRequest.Payload(1L, true),
+                                    new TermAgreeRequest.Payload(2L, true)));
+            willDoNothing().given(termService).agreeTerm(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/terms")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON204"))
+                    .andExpect(jsonPath("$.message").value("요청 성공 및 반환값 없음"));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void Device_Token을_비워두면_예외가_발생한다(String deviceToken) throws Exception {
+            // given
+            TermAgreeRequest request =
+                    new TermAgreeRequest(
+                            deviceToken,
+                            List.of(
+                                    new TermAgreeRequest.Payload(1L, true),
+                                    new TermAgreeRequest.Payload(2L, true)));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/terms")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.deviceToken").value("Device Token은 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 약관_동의_정보를_비워두면_예외가_발생한다() throws Exception {
+            // given
+            TermAgreeRequest request = new TermAgreeRequest("testDeviceToken", List.of());
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/terms")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.payloads").value("약관 동의 정보는 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 약관_ID를_비워두면_예외가_발생한다() throws Exception {
+            // given
+            TermAgreeRequest request =
+                    new TermAgreeRequest(
+                            "testDeviceToken", List.of(new TermAgreeRequest.Payload(null, true)));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/terms")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.termId").value("약관 ID는 비워둘 수 없습니다."));
+        }
+
+        @Test
+        void 약관_동의_여부를_비워두면_예외가_발생한다() throws Exception {
+            // given
+            TermAgreeRequest request =
+                    new TermAgreeRequest(
+                            "testDeviceToken", List.of(new TermAgreeRequest.Payload(1L, null)));
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            post("/terms")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.agreed").value("약관 동의 여부는 비워둘 수 없습니다."));
+        }
+    }
+}

--- a/clokey-api/src/test/java/org/clokey/domain/term/service/TermServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/term/service/TermServiceTest.java
@@ -1,0 +1,133 @@
+package org.clokey.domain.term.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import org.clokey.IntegrationTest;
+import org.clokey.domain.member.repository.MemberRepository;
+import org.clokey.domain.term.dto.TermAgreeRequest;
+import org.clokey.domain.term.exception.TermErrorCode;
+import org.clokey.domain.term.repository.MemberTermRepository;
+import org.clokey.domain.term.repository.TermRepository;
+import org.clokey.exception.BaseCustomException;
+import org.clokey.global.util.MemberUtil;
+import org.clokey.member.entity.Member;
+import org.clokey.member.entity.OauthInfo;
+import org.clokey.member.enums.OauthProvider;
+import org.clokey.term.entity.MemberTerm;
+import org.clokey.term.entity.Term;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+class TermServiceTest extends IntegrationTest {
+
+    @Autowired MemberRepository memberRepository;
+    @Autowired TermRepository termRepository;
+    @Autowired MemberTermRepository memberTermRepository;
+    @Autowired TermService termService;
+
+    @MockitoBean private MemberUtil memberUtil;
+
+    @Nested
+    class 약관에_동의할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            "testEmail",
+                            "testClokeyId",
+                            "testNickName",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO));
+            Member savedMember = memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(savedMember);
+
+            Term term1 = Term.createTerm("testTerm1", "testContent1", false);
+            Term term2 = Term.createTerm("testTerm2", "testContent2", false);
+            Term term3 = Term.createTerm("testTerm3", "testContent3", false);
+            Term term4 = Term.createTerm("testTerm4", "testContent4", true);
+            Term term5 = Term.createTerm("testTerm5", "testContent5", true);
+            termRepository.saveAll(List.of(term1, term2, term3, term4, term5));
+        }
+
+        @Test
+        @Transactional
+        void 유효한_요청이면_약관_정보와_Device_Token을_저장한다() {
+            // given
+            TermAgreeRequest request =
+                    new TermAgreeRequest(
+                            "testDeviceToken",
+                            List.of(
+                                    new TermAgreeRequest.Payload(1L, true),
+                                    new TermAgreeRequest.Payload(2L, true),
+                                    new TermAgreeRequest.Payload(3L, true),
+                                    new TermAgreeRequest.Payload(4L, false),
+                                    new TermAgreeRequest.Payload(5L, true)));
+
+            // when
+            termService.agreeTerm(request);
+
+            // then
+            Member member = memberRepository.findById(1L).orElseThrow();
+            List<MemberTerm> memberTerms =
+                    memberTermRepository.findAllById(List.of(1L, 2L, 3L, 4L, 5L));
+            Assertions.assertAll(
+                    () -> assertThat(member.getDeviceToken()).isEqualTo("testDeviceToken"),
+                    () ->
+                            assertThat(memberTerms)
+                                    .extracting("member.id", "term.id", "agreed")
+                                    .containsExactly(
+                                            tuple(1L, 1L, true),
+                                            tuple(1L, 2L, true),
+                                            tuple(1L, 3L, true),
+                                            tuple(1L, 4L, false),
+                                            tuple(1L, 5L, true)));
+        }
+
+        @Test
+        void 모든_약관에_대한_정보를_포함하지_않으면_예외가_발생한다() {
+            // given
+            TermAgreeRequest request =
+                    new TermAgreeRequest(
+                            "testDeviceToken",
+                            List.of(
+                                    new TermAgreeRequest.Payload(1L, true),
+                                    new TermAgreeRequest.Payload(2L, true),
+                                    new TermAgreeRequest.Payload(3L, true),
+                                    new TermAgreeRequest.Payload(4L, false)));
+
+            // when
+            assertThatThrownBy(() -> termService.agreeTerm(request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(TermErrorCode.TERMS_MISMATCH.getMessage());
+        }
+
+        @Test
+        void 필수_약관에_동의하지_않으면_예외가_발생한다() {
+            // given
+            TermAgreeRequest request =
+                    new TermAgreeRequest(
+                            "testDeviceToken",
+                            List.of(
+                                    new TermAgreeRequest.Payload(1L, true),
+                                    new TermAgreeRequest.Payload(2L, true),
+                                    new TermAgreeRequest.Payload(3L, false),
+                                    new TermAgreeRequest.Payload(4L, false),
+                                    new TermAgreeRequest.Payload(5L, false)));
+
+            // when
+            assertThatThrownBy(() -> termService.agreeTerm(request))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(TermErrorCode.NON_OPTIONAL_NOT_AGREED.getMessage());
+        }
+    }
+}

--- a/clokey-domain/src/main/java/org/clokey/member/entity/Member.java
+++ b/clokey-domain/src/main/java/org/clokey/member/entity/Member.java
@@ -143,4 +143,8 @@ public class Member extends BaseEntity {
         this.visibility =
                 (this.visibility == Visibility.PUBLIC) ? Visibility.PRIVATE : Visibility.PUBLIC;
     }
+
+    public void updateDeviceToken(String deviceToken) {
+        this.deviceToken = deviceToken;
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/term/entity/MemberTerm.java
+++ b/clokey-domain/src/main/java/org/clokey/term/entity/MemberTerm.java
@@ -28,13 +28,16 @@ public class MemberTerm extends BaseEntity {
     @NotNull
     private Term term;
 
+    @NotNull private boolean agreed;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private MemberTerm(Member member, Term term) {
+    private MemberTerm(Member member, Term term, boolean agreed) {
         this.member = member;
         this.term = term;
+        this.agreed = agreed;
     }
 
-    public static MemberTerm createMemberTerm(Member member, Term term) {
-        return MemberTerm.builder().member(member).term(term).build();
+    public static MemberTerm createMemberTerm(Member member, Term term, boolean agreed) {
+        return MemberTerm.builder().member(member).term(term).agreed(agreed).build();
     }
 }

--- a/clokey-domain/src/main/resources/db/migration/V1__init.sql
+++ b/clokey-domain/src/main/resources/db/migration/V1__init.sql
@@ -345,6 +345,7 @@ CREATE TABLE member_term (
 
                              member_id BIGINT NOT NULL,
                              term_id BIGINT NOT NULL,
+                             agreed BOOLEAN NOT NULL,
 
                              created_at DATETIME(6) NOT NULL,
                              updated_at DATETIME(6) NOT NULL,


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #39

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 약관 동의 API 구현

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 약관 동의 API를 구현했습니다
- 약관 별로 동의/수정 시점을 추적하기 위해서 매핑 테이블 형태를 유지했습니다. 다만, 매번 row를 재생성 하는 것을 방지하고자 동의 여부를 boolean으로 필드로 보관합니다.
- 약관 ID 정보를 Enum으로 관리하고 약관 관련 정보를 Enum을 통해서 받을 수 있습니다.