### PR TITLE
[refactor/#41] 약관 동의 API에서 device token 입력 분리 

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/auth/controller/AuthController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.clokey.code.GlobalBaseSuccessCode;
+import org.clokey.domain.auth.dto.request.DeviceTokenRenewRequest;
 import org.clokey.domain.auth.dto.request.TokenReissueRequest;
 import org.clokey.domain.auth.dto.response.TokenResponse;
 import org.clokey.domain.auth.dto.response.UserStatusResponse;
@@ -27,6 +28,14 @@ public class AuthController {
     public BaseResponse<UserStatusResponse> getUserStatus() {
         UserStatusResponse response = authService.getUserStatus();
         return BaseResponse.onSuccess(GlobalBaseSuccessCode.OK, response);
+    }
+
+    @PatchMapping("/device-token")
+    @Operation(summary = "Device Token 갱신", description = "디바이스 토큰을 갱신합니다.")
+    public BaseResponse<Void> renewDeviceToken(
+            @Valid @RequestBody DeviceTokenRenewRequest request) {
+        authService.renewDeviceToken(request);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.NO_CONTENT, null);
     }
 
     @PostMapping("/reissue-token")

--- a/clokey-api/src/main/java/org/clokey/domain/auth/dto/request/DeviceTokenRenewRequest.java
+++ b/clokey-api/src/main/java/org/clokey/domain/auth/dto/request/DeviceTokenRenewRequest.java
@@ -1,0 +1,9 @@
+package org.clokey.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record DeviceTokenRenewRequest(
+        @NotBlank(message = "Device Token은 비워둘 수 없습니다.")
+                @Schema(description = "기기를 식별할 수 있는 Device Token")
+                String deviceToken) {}

--- a/clokey-api/src/main/java/org/clokey/domain/auth/service/AuthService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package org.clokey.domain.auth.service;
 
+import org.clokey.domain.auth.dto.request.DeviceTokenRenewRequest;
 import org.clokey.domain.auth.dto.request.TokenReissueRequest;
 import org.clokey.domain.auth.dto.response.TokenResponse;
 import org.clokey.domain.auth.dto.response.UserStatusResponse;
@@ -7,6 +8,8 @@ import org.clokey.domain.auth.dto.response.UserStatusResponse;
 public interface AuthService {
 
     UserStatusResponse getUserStatus();
+
+    void renewDeviceToken(DeviceTokenRenewRequest request);
 
     TokenResponse reissueTokens(TokenReissueRequest request);
 

--- a/clokey-api/src/main/java/org/clokey/domain/auth/service/AuthServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/auth/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package org.clokey.domain.auth.service;
 import lombok.RequiredArgsConstructor;
 import org.clokey.domain.auth.dto.AccessTokenDto;
 import org.clokey.domain.auth.dto.RefreshTokenDto;
+import org.clokey.domain.auth.dto.request.DeviceTokenRenewRequest;
 import org.clokey.domain.auth.dto.request.TokenReissueRequest;
 import org.clokey.domain.auth.dto.response.TokenResponse;
 import org.clokey.domain.auth.dto.response.UserStatusResponse;
@@ -41,6 +42,15 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
+    @Transactional
+    public void renewDeviceToken(DeviceTokenRenewRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        currentMember.updateDeviceToken(request.deviceToken());
+    }
+
+    @Override
+    @Transactional
     public TokenResponse reissueTokens(TokenReissueRequest request) {
         RefreshTokenDto oldRefreshToken =
                 jwtTokenService.retrieveRefreshToken(request.refreshToken());
@@ -57,6 +67,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
+    @Transactional
     public void logoutUser() {
         final Member currentMember = memberUtil.getCurrentMember();
 

--- a/clokey-api/src/main/java/org/clokey/domain/term/dto/TermAgreeRequest.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/dto/TermAgreeRequest.java
@@ -2,15 +2,11 @@ package org.clokey.domain.term.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record TermAgreeRequest(
-        @NotBlank(message = "Device Token은 비워둘 수 없습니다.")
-                @Schema(description = "기기를 식별할 수 있는 Device Token")
-                String deviceToken,
         @NotEmpty(message = "약관 동의 정보는 비워둘 수 없습니다.") @Valid @Schema(description = "약관 동의 정보 리스트")
                 List<Payload> payloads) {
     public record Payload(

--- a/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
@@ -35,8 +35,6 @@ public class TermServiceImpl implements TermService {
         validateAllTermContained(request);
         validateAgreedNonOptionalTerms(request);
 
-        currentMember.updateDeviceToken(request.deviceToken());
-
         List<MemberTerm> memberTerms =
                 request.payloads().stream()
                         .map(

--- a/clokey-api/src/test/java/org/clokey/domain/auth/controller/AuthControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/auth/controller/AuthControllerTest.java
@@ -3,11 +3,11 @@ package org.clokey.domain.auth.controller;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.clokey.domain.auth.dto.request.DeviceTokenRenewRequest;
 import org.clokey.domain.auth.dto.request.TokenReissueRequest;
 import org.clokey.domain.auth.dto.response.TokenResponse;
 import org.clokey.domain.auth.dto.response.UserStatusResponse;
@@ -71,6 +71,51 @@ class AuthControllerTest {
                     .andExpect(jsonPath("$.code").value("COMMON200"))
                     .andExpect(jsonPath("$.message").value("성공입니다."))
                     .andExpect(jsonPath("$.result.registerStatus").value("NOT_AGREED"));
+        }
+    }
+
+    @Nested
+    class 디바이스_토큰_갱신_요청_시 {
+
+        @Test
+        void 유효한_요청이면_디바이스_토큰을_갱신하고_NO_CONTENT를_반환한다() throws Exception {
+            // given
+            DeviceTokenRenewRequest request = new DeviceTokenRenewRequest("testDeviceToken");
+            willDoNothing().given(authService).renewDeviceToken(request);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/auth/device-token")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON204"))
+                    .andExpect(jsonPath("$.message").value("요청 성공 및 반환값 없음"));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {" "})
+        void Device_Token을_비워두면_예외가_발생한다(String deviceToken) throws Exception {
+            // given
+            DeviceTokenRenewRequest request = new DeviceTokenRenewRequest(deviceToken);
+
+            // when & then
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/auth/device-token")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)));
+
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.isSuccess").value(false))
+                    .andExpect(jsonPath("$.code").value("COMMON400"))
+                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                    .andExpect(jsonPath("$.result.deviceToken").value("Device Token은 비워둘 수 없습니다."));
         }
     }
 

--- a/clokey-api/src/test/java/org/clokey/domain/auth/service/AuthServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/auth/service/AuthServiceTest.java
@@ -13,6 +13,7 @@ import org.clokey.RedisCleaner;
 import org.clokey.auth.entity.RefreshToken;
 import org.clokey.domain.auth.dto.AccessTokenDto;
 import org.clokey.domain.auth.dto.RefreshTokenDto;
+import org.clokey.domain.auth.dto.request.DeviceTokenRenewRequest;
 import org.clokey.domain.auth.dto.request.TokenReissueRequest;
 import org.clokey.domain.auth.dto.response.TokenResponse;
 import org.clokey.domain.auth.dto.response.UserStatusResponse;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
 
 class AuthServiceTest extends IntegrationTest {
 
@@ -91,6 +93,38 @@ class AuthServiceTest extends IntegrationTest {
 
             // then
             assertThat(response.registerStatus()).isEqualTo(RegisterStatus.NOT_AGREED);
+        }
+    }
+
+    @Nested
+    class 디바이스_토큰을_갱신할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member =
+                    Member.createMember(
+                            "testEmail",
+                            "testClokeyId",
+                            "testNickName",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO));
+            member.updateDeviceToken("testDeviceToken");
+
+            memberRepository.save(member);
+            given(memberUtil.getCurrentMember()).willReturn(member);
+        }
+
+        @Test
+        @Transactional
+        void 유효한_요청이면_Device_Token을_갱신한다() {
+            // given
+            DeviceTokenRenewRequest request = new DeviceTokenRenewRequest("newDeviceToken");
+
+            // when
+            authService.renewDeviceToken(request);
+
+            // then
+            assertThat(memberRepository.findById(1L).orElseThrow().getDeviceToken())
+                    .isEqualTo("newDeviceToken");
         }
     }
 

--- a/clokey-api/src/test/java/org/clokey/domain/term/controller/TermControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/term/controller/TermControllerTest.java
@@ -12,10 +12,6 @@ import org.clokey.domain.term.dto.TermAgreeRequest;
 import org.clokey.domain.term.service.TermService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EmptySource;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -41,7 +37,6 @@ class TermControllerTest {
             // given
             TermAgreeRequest request =
                     new TermAgreeRequest(
-                            "testDeviceToken",
                             List.of(
                                     new TermAgreeRequest.Payload(1L, true),
                                     new TermAgreeRequest.Payload(2L, true)));
@@ -60,37 +55,10 @@ class TermControllerTest {
                     .andExpect(jsonPath("$.message").value("요청 성공 및 반환값 없음"));
         }
 
-        @ParameterizedTest
-        @NullSource
-        @EmptySource
-        @ValueSource(strings = {" "})
-        void Device_Token을_비워두면_예외가_발생한다(String deviceToken) throws Exception {
-            // given
-            TermAgreeRequest request =
-                    new TermAgreeRequest(
-                            deviceToken,
-                            List.of(
-                                    new TermAgreeRequest.Payload(1L, true),
-                                    new TermAgreeRequest.Payload(2L, true)));
-
-            // when & then
-            ResultActions perform =
-                    mockMvc.perform(
-                            post("/terms")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(request)));
-
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.isSuccess").value(false))
-                    .andExpect(jsonPath("$.code").value("COMMON400"))
-                    .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
-                    .andExpect(jsonPath("$.result.deviceToken").value("Device Token은 비워둘 수 없습니다."));
-        }
-
         @Test
         void 약관_동의_정보를_비워두면_예외가_발생한다() throws Exception {
             // given
-            TermAgreeRequest request = new TermAgreeRequest("testDeviceToken", List.of());
+            TermAgreeRequest request = new TermAgreeRequest(List.of());
 
             // when & then
             ResultActions perform =
@@ -110,8 +78,7 @@ class TermControllerTest {
         void 약관_ID를_비워두면_예외가_발생한다() throws Exception {
             // given
             TermAgreeRequest request =
-                    new TermAgreeRequest(
-                            "testDeviceToken", List.of(new TermAgreeRequest.Payload(null, true)));
+                    new TermAgreeRequest(List.of(new TermAgreeRequest.Payload(null, true)));
 
             // when & then
             ResultActions perform =
@@ -131,8 +98,7 @@ class TermControllerTest {
         void 약관_동의_여부를_비워두면_예외가_발생한다() throws Exception {
             // given
             TermAgreeRequest request =
-                    new TermAgreeRequest(
-                            "testDeviceToken", List.of(new TermAgreeRequest.Payload(1L, null)));
+                    new TermAgreeRequest(List.of(new TermAgreeRequest.Payload(1L, null)));
 
             // when & then
             ResultActions perform =

--- a/clokey-api/src/test/java/org/clokey/domain/term/service/TermServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/term/service/TermServiceTest.java
@@ -20,7 +20,6 @@ import org.clokey.member.entity.OauthInfo;
 import org.clokey.member.enums.OauthProvider;
 import org.clokey.term.entity.MemberTerm;
 import org.clokey.term.entity.Term;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -65,7 +64,6 @@ class TermServiceTest extends IntegrationTest {
             // given
             TermAgreeRequest request =
                     new TermAgreeRequest(
-                            "testDeviceToken",
                             List.of(
                                     new TermAgreeRequest.Payload(1L, true),
                                     new TermAgreeRequest.Payload(2L, true),
@@ -80,17 +78,15 @@ class TermServiceTest extends IntegrationTest {
             Member member = memberRepository.findById(1L).orElseThrow();
             List<MemberTerm> memberTerms =
                     memberTermRepository.findAllById(List.of(1L, 2L, 3L, 4L, 5L));
-            Assertions.assertAll(
-                    () -> assertThat(member.getDeviceToken()).isEqualTo("testDeviceToken"),
-                    () ->
-                            assertThat(memberTerms)
-                                    .extracting("member.id", "term.id", "agreed")
-                                    .containsExactly(
-                                            tuple(1L, 1L, true),
-                                            tuple(1L, 2L, true),
-                                            tuple(1L, 3L, true),
-                                            tuple(1L, 4L, false),
-                                            tuple(1L, 5L, true)));
+
+            assertThat(memberTerms)
+                    .extracting("member.id", "term.id", "agreed")
+                    .containsExactly(
+                            tuple(1L, 1L, true),
+                            tuple(1L, 2L, true),
+                            tuple(1L, 3L, true),
+                            tuple(1L, 4L, false),
+                            tuple(1L, 5L, true));
         }
 
         @Test
@@ -98,7 +94,6 @@ class TermServiceTest extends IntegrationTest {
             // given
             TermAgreeRequest request =
                     new TermAgreeRequest(
-                            "testDeviceToken",
                             List.of(
                                     new TermAgreeRequest.Payload(1L, true),
                                     new TermAgreeRequest.Payload(2L, true),
@@ -116,7 +111,6 @@ class TermServiceTest extends IntegrationTest {
             // given
             TermAgreeRequest request =
                     new TermAgreeRequest(
-                            "testDeviceToken",
                             List.of(
                                     new TermAgreeRequest.Payload(1L, true),
                                     new TermAgreeRequest.Payload(2L, true),


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #41 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- device token을 갱신하는 API를 분리했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 원래는 약관 동의시에 device token을 갱신했는데, API를 분리했습니다.
- 이유는 재로그인시마다 갱신이 필요하기 때문입니다.