### PR TITLE
[feat/#45] 나의 선택 약관 정보 조회 및 변경 API 구현

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/term/controller/TermController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/controller/TermController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.clokey.code.GlobalBaseSuccessCode;
 import org.clokey.domain.term.dto.request.TermAgreeRequest;
+import org.clokey.domain.term.dto.response.MyOptionalTermResponse;
 import org.clokey.domain.term.dto.response.TermListResponse;
 import org.clokey.domain.term.service.TermService;
 import org.clokey.response.BaseResponse;
@@ -31,5 +32,19 @@ public class TermController {
     public BaseResponse<Void> agreeTerm(@Valid @RequestBody TermAgreeRequest request) {
         termService.agreeTerm(request);
         return BaseResponse.onSuccess(GlobalBaseSuccessCode.NO_CONTENT, null);
+    }
+
+    @GetMapping("/my-optional")
+    @Operation(summary = "나의 선택 약관 조회", description = "나의 선택 약관 정보 조회 API")
+    public BaseResponse<MyOptionalTermResponse> getMyOptionalTerms() {
+        MyOptionalTermResponse response = termService.getMyOptionalTerms();
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.OK, response);
+    }
+
+    @PatchMapping("/my-optional-toggle")
+    @Operation(summary = "나의 선택 약관 수정", description = "나의 선택 약관 수정 API")
+    public BaseResponse<Void> toggleMyOptionalTerms(@RequestParam Long termId) {
+        termService.toggleMyOptionalTerms(termId);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.OK, null);
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/term/dto/response/MyOptionalTermResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/dto/response/MyOptionalTermResponse.java
@@ -15,7 +15,7 @@ public record MyOptionalTermResponse(@Schema(description = "나의 선택 약관
                         .map(
                                 term ->
                                         new MyOptionalTermResponse.Payload(
-                                                term.getId(), term.isAgreed()))
+                                                term.getTerm().getId(), term.isAgreed()))
                         .toList();
 
         return new MyOptionalTermResponse(payloads);

--- a/clokey-api/src/main/java/org/clokey/domain/term/dto/response/MyOptionalTermResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/dto/response/MyOptionalTermResponse.java
@@ -1,0 +1,23 @@
+package org.clokey.domain.term.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.clokey.term.entity.MemberTerm;
+
+public record MyOptionalTermResponse(@Schema(description = "나의 선택 약관 정보") List<Payload> payloads) {
+    public record Payload(
+            @Schema(description = "약관 ID") Long termId,
+            @Schema(description = "동의 여부") boolean agreed) {}
+
+    public static MyOptionalTermResponse from(List<MemberTerm> memberTerms) {
+        List<MyOptionalTermResponse.Payload> payloads =
+                memberTerms.stream()
+                        .map(
+                                term ->
+                                        new MyOptionalTermResponse.Payload(
+                                                term.getId(), term.isAgreed()))
+                        .toList();
+
+        return new MyOptionalTermResponse(payloads);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/term/dto/response/TermListResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/dto/response/TermListResponse.java
@@ -12,7 +12,7 @@ public record TermListResponse(
             @Schema(description = "약관 내용") String body,
             @Schema(description = "필수 동의 여부") boolean optional) {}
 
-    public static TermListResponse of(List<Term> terms) {
+    public static TermListResponse from(List<Term> terms) {
         List<TermListResponse.Payload> payloads =
                 terms.stream()
                         .map(

--- a/clokey-api/src/main/java/org/clokey/domain/term/enums/TermInfo.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/enums/TermInfo.java
@@ -24,6 +24,10 @@ public enum TermInfo {
                 .toList();
     }
 
+    public static List<Long> getOptionalIds() {
+        return Arrays.stream(values()).filter(TermInfo::isOptional).map(TermInfo::getId).toList();
+    }
+
     public static List<Long> getAllIds() {
         return Arrays.stream(values()).map(TermInfo::getId).toList();
     }

--- a/clokey-api/src/main/java/org/clokey/domain/term/exception/TermErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/exception/TermErrorCode.java
@@ -10,6 +10,7 @@ import org.clokey.exception.BaseErrorCode;
 public enum TermErrorCode implements BaseErrorCode {
     TERMS_MISMATCH(400, "TERM_4001", "응답한 약관 ID들이 DB에 존재하는 약관ID들과 일치하지 않습니다."),
     NON_OPTIONAL_NOT_AGREED(400, "TERM_4002", "필수 약관에 동의하지 않았습니다."),
+    MEMBER_SKIPPED_TERM_AGREEMENT(400, "TERM_4003", "약관 동의 절차를 수행하지 않은 회원입니다."),
 
     TERM_NOT_FOUND(404, "TERM_4041", "약관이 존재하지 않습니다.");
 

--- a/clokey-api/src/main/java/org/clokey/domain/term/exception/TermErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/exception/TermErrorCode.java
@@ -10,10 +10,11 @@ import org.clokey.exception.BaseErrorCode;
 public enum TermErrorCode implements BaseErrorCode {
     TERMS_MISMATCH(400, "TERM_4001", "응답한 약관 ID들이 DB에 존재하는 약관ID들과 일치하지 않습니다."),
     NON_OPTIONAL_NOT_AGREED(400, "TERM_4002", "필수 약관에 동의하지 않았습니다."),
-    MEMBER_SKIPPED_TERM_AGREEMENT(400, "TERM_4003", "약관 동의 절차를 수행하지 않은 회원입니다."),
-    NOT_OPTIONAL_TERM(400, "TERM_4004", "선택 약관ID가 아닙니다."),
 
-    TERM_NOT_FOUND(404, "TERM_4041", "약관이 존재하지 않습니다.");
+    TERM_NOT_FOUND(404, "TERM_4041", "약관이 존재하지 않습니다."),
+    MEMBER_SKIPPED_TERM_AGREEMENT(404, "TERM_4042", "약관 동의 절차를 수행하지 않은 회원입니다."),
+    NOT_OPTIONAL_TERM(404, "TERM_4043", "선택 약관ID가 아닙니다."),
+    ;
 
     private final int status;
     private final String code;

--- a/clokey-api/src/main/java/org/clokey/domain/term/exception/TermErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/exception/TermErrorCode.java
@@ -11,6 +11,7 @@ public enum TermErrorCode implements BaseErrorCode {
     TERMS_MISMATCH(400, "TERM_4001", "응답한 약관 ID들이 DB에 존재하는 약관ID들과 일치하지 않습니다."),
     NON_OPTIONAL_NOT_AGREED(400, "TERM_4002", "필수 약관에 동의하지 않았습니다."),
     MEMBER_SKIPPED_TERM_AGREEMENT(400, "TERM_4003", "약관 동의 절차를 수행하지 않은 회원입니다."),
+    NOT_OPTIONAL_TERM(400, "TERM_4004", "선택 약관ID가 아닙니다."),
 
     TERM_NOT_FOUND(404, "TERM_4041", "약관이 존재하지 않습니다.");
 

--- a/clokey-api/src/main/java/org/clokey/domain/term/repository/MemberTermRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/repository/MemberTermRepository.java
@@ -2,7 +2,6 @@ package org.clokey.domain.term.repository;
 
 import java.util.List;
 import java.util.Optional;
-import org.clokey.member.entity.Member;
 import org.clokey.term.entity.MemberTerm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,5 +12,4 @@ public interface MemberTermRepository extends JpaRepository<MemberTerm, Long> {
     List<MemberTerm> findByMemberIdAndTermIdIn(Long memberId, List<Long> termIds);
 
     Optional<MemberTerm> findByMemberIdAndTermId(Long memberId, Long termId);
-}
 }

--- a/clokey-api/src/main/java/org/clokey/domain/term/repository/MemberTermRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/repository/MemberTermRepository.java
@@ -1,9 +1,17 @@
 package org.clokey.domain.term.repository;
 
+import java.util.List;
+import java.util.Optional;
+import org.clokey.member.entity.Member;
 import org.clokey.term.entity.MemberTerm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberTermRepository extends JpaRepository<MemberTerm, Long> {
 
     boolean existsByMemberId(Long memberId);
+
+    List<MemberTerm> findByMemberIdAndTermIdIn(Long memberId, List<Long> termIds);
+
+    Optional<MemberTerm> findByMemberIdAndTermId(Long memberId, Long termId);
+}
 }

--- a/clokey-api/src/main/java/org/clokey/domain/term/service/TermService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/service/TermService.java
@@ -1,6 +1,7 @@
 package org.clokey.domain.term.service;
 
 import org.clokey.domain.term.dto.request.TermAgreeRequest;
+import org.clokey.domain.term.dto.response.MyOptionalTermResponse;
 import org.clokey.domain.term.dto.response.TermListResponse;
 
 public interface TermService {
@@ -8,4 +9,8 @@ public interface TermService {
     TermListResponse getTerms();
 
     void agreeTerm(TermAgreeRequest request);
+
+    MyOptionalTermResponse getMyOptionalTerms();
+
+    void toggleMyOptionalTerms(Long termId);
 }

--- a/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
@@ -70,7 +70,7 @@ public class TermServiceImpl implements TermService {
     public MyOptionalTermResponse getMyOptionalTerms() {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        List<MemberTerm> memberTerms =
+        final List<MemberTerm> memberTerms =
                 getByMemberIdAndTermIdIn(currentMember.getId(), TermInfo.getOptionalIds());
 
         return MyOptionalTermResponse.from(memberTerms);
@@ -81,8 +81,16 @@ public class TermServiceImpl implements TermService {
     public void toggleMyOptionalTerms(Long termId) {
         final Member currentMember = memberUtil.getCurrentMember();
 
+        validateIsOptionalTerm(termId);
+
         MemberTerm memberTerm = getByMemberIdAndTermId(currentMember.getId(), termId);
         memberTerm.toggleAgreed();
+    }
+
+    private void validateIsOptionalTerm(Long termId) {
+        if (!TermInfo.getOptionalIds().contains(termId)) {
+            throw new BaseCustomException(TermErrorCode.NOT_OPTIONAL_TERM);
+        }
     }
 
     private void validateAllTermContained(TermAgreeRequest request) {

--- a/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
@@ -121,6 +121,7 @@ public class TermServiceImpl implements TermService {
         }
     }
 
+    /** 선택 약관만을 DB에서 확인하지만, 선택 약관 동의가 되어 있지 않는 경우 약관 동의 절차를 생략했다고 판단. */
     private List<MemberTerm> getByMemberIdAndTermIdIn(Long memberId, List<Long> termIds) {
         List<MemberTerm> memberTerms =
                 memberTermRepository.findByMemberIdAndTermIdIn(memberId, termIds);

--- a/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/term/service/TermServiceImpl.java
@@ -2,9 +2,11 @@ package org.clokey.domain.term.service;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.clokey.domain.term.dto.request.TermAgreeRequest;
+import org.clokey.domain.term.dto.response.MyOptionalTermResponse;
 import org.clokey.domain.term.dto.response.TermListResponse;
 import org.clokey.domain.term.enums.TermInfo;
 import org.clokey.domain.term.exception.TermErrorCode;
@@ -32,7 +34,7 @@ public class TermServiceImpl implements TermService {
     public TermListResponse getTerms() {
         final List<Term> terms = termRepository.findAll();
 
-        return TermListResponse.of(terms);
+        return TermListResponse.from(terms);
     }
 
     @Override
@@ -64,6 +66,25 @@ public class TermServiceImpl implements TermService {
         memberTermRepository.saveAll(memberTerms);
     }
 
+    @Override
+    public MyOptionalTermResponse getMyOptionalTerms() {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        List<MemberTerm> memberTerms =
+                getByMemberIdAndTermIdIn(currentMember.getId(), TermInfo.getOptionalIds());
+
+        return MyOptionalTermResponse.from(memberTerms);
+    }
+
+    @Override
+    @Transactional
+    public void toggleMyOptionalTerms(Long termId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        MemberTerm memberTerm = getByMemberIdAndTermId(currentMember.getId(), termId);
+        memberTerm.toggleAgreed();
+    }
+
     private void validateAllTermContained(TermAgreeRequest request) {
         List<Long> allTermIds = TermInfo.getAllIds();
 
@@ -90,5 +111,21 @@ public class TermServiceImpl implements TermService {
         if (!agreedIds.containsAll(requiredIds)) {
             throw new BaseCustomException(TermErrorCode.NON_OPTIONAL_NOT_AGREED);
         }
+    }
+
+    private List<MemberTerm> getByMemberIdAndTermIdIn(Long memberId, List<Long> termIds) {
+        List<MemberTerm> memberTerms =
+                memberTermRepository.findByMemberIdAndTermIdIn(memberId, termIds);
+        return Optional.of(memberTerms)
+                .filter(list -> !list.isEmpty())
+                .orElseThrow(
+                        () -> new BaseCustomException(TermErrorCode.MEMBER_SKIPPED_TERM_AGREEMENT));
+    }
+
+    private MemberTerm getByMemberIdAndTermId(Long memberId, Long termId) {
+        return memberTermRepository
+                .findByMemberIdAndTermId(memberId, termId)
+                .orElseThrow(
+                        () -> new BaseCustomException(TermErrorCode.MEMBER_SKIPPED_TERM_AGREEMENT));
     }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/term/controller/TermControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/term/controller/TermControllerTest.java
@@ -2,14 +2,14 @@ package org.clokey.domain.term.controller;
 
 import static org.hamcrest.Matchers.contains;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.clokey.domain.term.dto.request.TermAgreeRequest;
+import org.clokey.domain.term.dto.response.MyOptionalTermResponse;
 import org.clokey.domain.term.dto.response.TermListResponse;
 import org.clokey.domain.term.service.TermService;
 import org.junit.jupiter.api.Nested;
@@ -170,6 +170,57 @@ class TermControllerTest {
                     .andExpect(jsonPath("$.code").value("COMMON400"))
                     .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
                     .andExpect(jsonPath("$.result.agreed").value("약관 동의 여부는 비워둘 수 없습니다."));
+        }
+    }
+
+    @Nested
+    class 나의_선택_약관_정보_조회_요청_시 {
+
+        @Test
+        void 유효한_요청이면_나의_선택_약관_정보를_반환한다() throws Exception {
+            // given
+            MyOptionalTermResponse response =
+                    new MyOptionalTermResponse(
+                            List.of(
+                                    new MyOptionalTermResponse.Payload(4L, true),
+                                    new MyOptionalTermResponse.Payload(5L, true)));
+            given(termService.getMyOptionalTerms()).willReturn(response);
+
+            // when
+            ResultActions perform =
+                    mockMvc.perform(
+                            get("/terms/my-optional").contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.message").value("성공입니다."))
+                    .andExpect(jsonPath("$.result.payloads[*].termId").value(contains(4, 5)))
+                    .andExpect(jsonPath("$.result.payloads[*].agreed").value(contains(true, true)));
+        }
+    }
+
+    @Nested
+    class 나의_선택_약관_수정_요청_시 {
+
+        @Test
+        void 유효한_요청이면_나의_선택_약관_정보를_수정하고_NO_CONTENT를_반환한다() throws Exception {
+            // given
+            willDoNothing().given(termService).toggleMyOptionalTerms(4L);
+
+            // when
+            ResultActions perform =
+                    mockMvc.perform(
+                            patch("/terms/my-optional-toggle")
+                                    .param("termId", "4")
+                                    .contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.message").value("성공입니다."));
         }
     }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/term/service/TermServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/term/service/TermServiceTest.java
@@ -6,9 +6,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.mockito.BDDMockito.given;
 
 import java.util.List;
+import org.assertj.core.groups.Tuple;
 import org.clokey.IntegrationTest;
 import org.clokey.domain.member.repository.MemberRepository;
 import org.clokey.domain.term.dto.request.TermAgreeRequest;
+import org.clokey.domain.term.dto.response.MyOptionalTermResponse;
 import org.clokey.domain.term.dto.response.TermListResponse;
 import org.clokey.domain.term.exception.TermErrorCode;
 import org.clokey.domain.term.repository.MemberTermRepository;
@@ -23,6 +25,8 @@ import org.clokey.term.entity.Term;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
@@ -161,6 +165,119 @@ class TermServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> termService.agreeTerm(request))
                     .isInstanceOf(BaseCustomException.class)
                     .hasMessage(TermErrorCode.NON_OPTIONAL_NOT_AGREED.getMessage());
+        }
+    }
+
+    @Nested
+    class 나의_선택_약관_정보_조회를_요청할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            "testEmail",
+                            "testClokeyId1",
+                            "testNickName1",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO));
+            Member member2 =
+                    Member.createMember(
+                            "testEmail2",
+                            "testClokeyId2",
+                            "testNickName2",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO));
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Term term1 = Term.createTerm("testTerm1", "testContent1", false);
+            Term term2 = Term.createTerm("testTerm2", "testContent2", false);
+            Term term3 = Term.createTerm("testTerm3", "testContent3", false);
+            Term term4 = Term.createTerm("testTerm4", "testContent4", true);
+            Term term5 = Term.createTerm("testTerm5", "testContent5", true);
+            termRepository.saveAll(List.of(term1, term2, term3, term4, term5));
+
+            MemberTerm memberTerm1 = MemberTerm.createMemberTerm(member1, term4, true);
+            MemberTerm memberTerm2 = MemberTerm.createMemberTerm(member1, term5, true);
+            memberTermRepository.saveAll(List.of(memberTerm1, memberTerm2));
+        }
+
+        @Test
+        void 유효한_요청이면_나의_선택_약관_정보를_반환한다() {
+            // when
+            MyOptionalTermResponse response = termService.getMyOptionalTerms();
+
+            // then
+            assertThat(response.payloads())
+                    .extracting("termId", "agreed")
+                    .containsExactly(tuple(4L, true), Tuple.tuple(5L, true));
+        }
+
+        @Test
+        void 약관_동의_절차를_수행하지_않은_회원이_요청할_경우_예외가_발생한다() {
+            // given
+            Member skippedTermProcess = memberRepository.findById(2L).orElseThrow();
+            given(memberUtil.getCurrentMember()).willReturn(skippedTermProcess);
+
+            // when & then
+            assertThatThrownBy(() -> termService.getMyOptionalTerms())
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(TermErrorCode.MEMBER_SKIPPED_TERM_AGREEMENT.getMessage());
+        }
+    }
+
+    @Nested
+    class 나의_선택_약관_정보_수정을_요청할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            "testEmail",
+                            "testClokeyId1",
+                            "testNickName1",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO));
+            Member member2 =
+                    Member.createMember(
+                            "testEmail2",
+                            "testClokeyId2",
+                            "testNickName2",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO));
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+
+            Term term1 = Term.createTerm("testTerm1", "testContent1", false);
+            Term term2 = Term.createTerm("testTerm2", "testContent2", false);
+            Term term3 = Term.createTerm("testTerm3", "testContent3", false);
+            Term term4 = Term.createTerm("testTerm4", "testContent4", true);
+            Term term5 = Term.createTerm("testTerm5", "testContent5", true);
+            termRepository.saveAll(List.of(term1, term2, term3, term4, term5));
+
+            MemberTerm memberTerm1 = MemberTerm.createMemberTerm(member1, term4, true);
+            MemberTerm memberTerm2 = MemberTerm.createMemberTerm(member2, term5, false);
+            memberTermRepository.saveAll(List.of(memberTerm1, memberTerm2));
+        }
+
+        @ParameterizedTest
+        @CsvSource({"4, false", "5, true"})
+        void 유효한_요청이면_선택_약관_정보를_수정한다(Long termId, boolean expectedAgreed) {
+            // when
+            termService.toggleMyOptionalTerms(termId);
+
+            // then
+            MemberTerm memberTerm =
+                    memberTermRepository.findByMemberIdAndTermId(1L, termId).orElseThrow();
+            assertThat(memberTerm.isAgreed()).isEqualTo(expectedAgreed);
+        }
+
+        @Test
+        void 약관_동의_절차를_수행하지_않은_회원이_요청할_경우_예외가_발생한다() {
+            // given
+            Member skippedTermProcess = memberRepository.findById(2L).orElseThrow();
+            given(memberUtil.getCurrentMember()).willReturn(skippedTermProcess);
+
+            // when & then
+            assertThatThrownBy(() -> termService.toggleMyOptionalTerms(4L))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(TermErrorCode.MEMBER_SKIPPED_TERM_AGREEMENT.getMessage());
         }
     }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/term/service/TermServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/term/service/TermServiceTest.java
@@ -252,7 +252,7 @@ class TermServiceTest extends IntegrationTest {
             termRepository.saveAll(List.of(term1, term2, term3, term4, term5));
 
             MemberTerm memberTerm1 = MemberTerm.createMemberTerm(member1, term4, true);
-            MemberTerm memberTerm2 = MemberTerm.createMemberTerm(member2, term5, false);
+            MemberTerm memberTerm2 = MemberTerm.createMemberTerm(member1, term5, false);
             memberTermRepository.saveAll(List.of(memberTerm1, memberTerm2));
         }
 
@@ -266,6 +266,14 @@ class TermServiceTest extends IntegrationTest {
             MemberTerm memberTerm =
                     memberTermRepository.findByMemberIdAndTermId(1L, termId).orElseThrow();
             assertThat(memberTerm.isAgreed()).isEqualTo(expectedAgreed);
+        }
+
+        @Test
+        void 선택_약관이_아닌_약관의_ID값을_입력할_경우_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> termService.toggleMyOptionalTerms(3L))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(TermErrorCode.NOT_OPTIONAL_TERM.getMessage());
         }
 
         @Test

--- a/clokey-domain/src/main/java/org/clokey/term/entity/MemberTerm.java
+++ b/clokey-domain/src/main/java/org/clokey/term/entity/MemberTerm.java
@@ -40,4 +40,8 @@ public class MemberTerm extends BaseEntity {
     public static MemberTerm createMemberTerm(Member member, Term term, boolean agreed) {
         return MemberTerm.builder().member(member).term(term).agreed(agreed).build();
     }
+
+    public void toggleAgreed() {
+        this.agreed = !this.agreed;
+    }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #45 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 나의 선택 약관 정보 조회 및 변경 API 구현

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 나의 선택 약관 정보 조회 API와 변경 API를 구현했습니다.

<img width="527" height="907" alt="스크린샷 2025-08-28 오전 2 37 21" src="https://github.com/user-attachments/assets/0ec8a545-eaf8-47d7-ad48-39f218bb4eb7" />

- 이 부분을 위한 기능입니다!
- 선택 약관 4번 5번에 대한 정보가 존재하지 않으면 약관 동의 프로세스를 건너뛴 사람으로 간주합니다.
- toggle(수정) 기능은 한 번에 두개가 바뀔 경우가 존재하지 않기 때문에 4L 또는 5L을 받아서 하나씩 바꾸도록 기능을 구현했습니다.

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
- Enum이 하드 코딩 되어 있는 부분은 약관을 DB에 저장하는 부분을 반영하면서도 편리하게 코딩하기 위함입니다!