### PR TITLE
[feat/#52] 회원 차단 API 구현

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/member/controller/MemberController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/controller/MemberController.java
@@ -38,9 +38,9 @@ public class MemberController {
         return BaseResponse.onSuccess(GlobalBaseSuccessCode.OK, response);
     }
 
-    @PostMapping("/block/{userId}")
+    @PostMapping("/block/{memberId}")
     @Operation(summary = "차단 토글 API", description = "차단 상태를 변경합니다.")
-    public BaseResponse<Void> toggleBlockStatus(@PathVariable("userId") Long memberId) {
+    public BaseResponse<Void> toggleBlockStatus(@PathVariable Long memberId) {
         memberService.toggleBlockStatus(memberId);
         return BaseResponse.onSuccess(GlobalBaseSuccessCode.NO_CONTENT, null);
     }

--- a/clokey-api/src/main/java/org/clokey/domain/member/controller/MemberController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/controller/MemberController.java
@@ -37,4 +37,11 @@ public class MemberController {
         DuplicatedIdCheckResponse response = memberService.checkDuplicateClokeyId(request);
         return BaseResponse.onSuccess(GlobalBaseSuccessCode.OK, response);
     }
+
+    @PostMapping("/block/{userId}")
+    @Operation(summary = "차단 토글 API", description = "차단 상태를 변경합니다.")
+    public BaseResponse<Void> toggleBlockStatus(@PathVariable("userId") Long memberId) {
+        memberService.toggleBlockStatus(memberId);
+        return BaseResponse.onSuccess(GlobalBaseSuccessCode.NO_CONTENT, null);
+    }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/member/exception/MemberErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/exception/MemberErrorCode.java
@@ -9,6 +9,8 @@ import org.clokey.exception.BaseErrorCode;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
     BANNED_MEMBER_TO_PUBLIC(400, "MEMBER_4001", "신고당한 회원은 공개로 전환할 수 없습니다."),
+    SELF_BLOCK_UNAVAILABLE(400, "MEMBER_4002", "자기 자신을 차단할 수 없습니다"),
+
     MEMBER_NOT_FOUND(404, "MEMBER_4041", "해당 회원을 찾을 수 없습니다.");
 
     private final int status;
@@ -17,6 +19,6 @@ public enum MemberErrorCode implements BaseErrorCode {
 
     @Override
     public ErrorReasonDto getErrorReason() {
-        return org.clokey.dto.ErrorReasonDto.of(status, code, message);
+        return ErrorReasonDto.of(status, code, message);
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/member/repository/BlockRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/repository/BlockRepository.java
@@ -1,6 +1,10 @@
 package org.clokey.domain.member.repository;
 
+import java.util.Optional;
 import org.clokey.member.entity.Block;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BlockRepository extends JpaRepository<Block, Long> {}
+public interface BlockRepository extends JpaRepository<Block, Long> {
+
+    Optional<Block> findByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+}

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberService.java
@@ -9,4 +9,6 @@ public interface MemberService {
     void updateProfile(ProfileUpdateRequest request);
 
     DuplicatedIdCheckResponse checkDuplicateClokeyId(DuplicatedIdCheckRequest request);
+
+    void toggleBlockStatus(Long memberId);
 }

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
@@ -59,26 +59,18 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void toggleBlockStatus(Long memberId) {
-        final Member currentMember = memberUtil.getCurrentMember();
+        final Member blocker = memberUtil.getCurrentMember();
+        final Member blocked = getMemberById(memberId);
 
-        validateSelfBlock(currentMember.getId(), memberId);
+        validateSelfBlock(blocker.getId(), blocked.getId());
 
         Optional<Block> existingBlock =
-                blockRepository.findByBlockerIdAndBlockedId(currentMember.getId(), memberId);
+                blockRepository.findByBlockerIdAndBlockedId(blocker.getId(), blocked.getId());
 
         if (existingBlock.isPresent()) {
             blockRepository.delete(existingBlock.get());
         } else {
-            final Member blocked =
-                    memberRepository
-                            .findById(memberId)
-                            .orElseThrow(
-                                    () ->
-                                            new BaseCustomException(
-                                                    MemberErrorCode.MEMBER_NOT_FOUND));
-
-            Block block = Block.createBlock(currentMember, blocked);
-
+            Block block = Block.createBlock(blocker, blocked);
             blockRepository.save(block);
         }
     }
@@ -95,5 +87,11 @@ public class MemberServiceImpl implements MemberService {
         if (blockerId.equals(blockedId)) {
             throw new BaseCustomException(MemberErrorCode.SELF_BLOCK_UNAVAILABLE);
         }
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository
+                .findById(memberId)
+                .orElseThrow(() -> new BaseCustomException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
@@ -1,13 +1,16 @@
 package org.clokey.domain.member.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.clokey.domain.member.dto.request.DuplicatedIdCheckRequest;
 import org.clokey.domain.member.dto.request.ProfileUpdateRequest;
 import org.clokey.domain.member.dto.response.DuplicatedIdCheckResponse;
 import org.clokey.domain.member.exception.MemberErrorCode;
+import org.clokey.domain.member.repository.BlockRepository;
 import org.clokey.domain.member.repository.MemberRepository;
 import org.clokey.exception.BaseCustomException;
 import org.clokey.global.util.MemberUtil;
+import org.clokey.member.entity.Block;
 import org.clokey.member.entity.Member;
 import org.clokey.member.enums.MemberStatus;
 import org.clokey.member.enums.Visibility;
@@ -22,6 +25,7 @@ public class MemberServiceImpl implements MemberService {
     private final MemberUtil memberUtil;
 
     private final MemberRepository memberRepository;
+    private final BlockRepository blockRepository;
 
     @Override
     @Transactional
@@ -53,11 +57,43 @@ public class MemberServiceImpl implements MemberService {
         return DuplicatedIdCheckResponse.of(duplicated);
     }
 
+    @Override
+    public void toggleBlockStatus(Long memberId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        validateSelfBlock(currentMember.getId(), memberId);
+
+        Optional<Block> existingBlock =
+                blockRepository.findByBlockerIdAndBlockedId(currentMember.getId(), memberId);
+
+        if (existingBlock.isPresent()) {
+            blockRepository.delete(existingBlock.get());
+        } else {
+            final Member blocked =
+                    memberRepository
+                            .findById(memberId)
+                            .orElseThrow(
+                                    () ->
+                                            new BaseCustomException(
+                                                    MemberErrorCode.MEMBER_NOT_FOUND));
+
+            Block block = Block.createBlock(currentMember, blocked);
+
+            blockRepository.save(block);
+        }
+    }
+
     private void validateVisualizeBannedMember(Member member, ProfileUpdateRequest request) {
         boolean banned = member.getMemberStatus().equals(MemberStatus.BANNED);
         boolean changeToPublic = request.visibility().equals(Visibility.PUBLIC);
         if (banned && changeToPublic) {
             throw new BaseCustomException(MemberErrorCode.BANNED_MEMBER_TO_PUBLIC);
+        }
+    }
+
+    private void validateSelfBlock(Long blockerId, Long blockedId) {
+        if (blockerId.equals(blockedId)) {
+            throw new BaseCustomException(MemberErrorCode.SELF_BLOCK_UNAVAILABLE);
         }
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
@@ -58,6 +58,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public void toggleBlockStatus(Long memberId) {
         final Member blocker = memberUtil.getCurrentMember();
         final Member blocked = getMemberById(memberId);

--- a/clokey-api/src/test/java/org/clokey/domain/member/controller/MemberControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/member/controller/MemberControllerTest.java
@@ -226,4 +226,24 @@ class MemberControllerTest {
                                     .value("Clokey ID는 영어 소문자, 숫자, 언더바(_), 점(.)만 허용됩니다."));
         }
     }
+
+    @Nested
+    class 차단_토글_요청_시 {
+
+        @Test
+        void 유효한_요청이면_차단을_토글하고_NO_CONTENT를_반환한다() throws Exception {
+            // given
+            willDoNothing().given(memberService).toggleBlockStatus(1L);
+
+            // when
+            ResultActions perform =
+                    mockMvc.perform(post("/users/block/1").contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("COMMON204"))
+                    .andExpect(jsonPath("$.message").value("요청 성공 및 반환값 없음"));
+        }
+    }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/member/service/MemberServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/member/service/MemberServiceTest.java
@@ -10,9 +10,11 @@ import org.clokey.TransactionUtil;
 import org.clokey.domain.member.dto.request.DuplicatedIdCheckRequest;
 import org.clokey.domain.member.dto.request.ProfileUpdateRequest;
 import org.clokey.domain.member.exception.MemberErrorCode;
+import org.clokey.domain.member.repository.BlockRepository;
 import org.clokey.domain.member.repository.MemberRepository;
 import org.clokey.exception.BaseCustomException;
 import org.clokey.global.util.MemberUtil;
+import org.clokey.member.entity.Block;
 import org.clokey.member.entity.Member;
 import org.clokey.member.entity.OauthInfo;
 import org.clokey.member.enums.MemberStatus;
@@ -31,6 +33,7 @@ class MemberServiceTest extends IntegrationTest {
 
     @Autowired private MemberService memberService;
     @Autowired private MemberRepository memberRepository;
+    @Autowired private BlockRepository blockRepository;
 
     @Autowired private TransactionUtil transactionUtil;
     @MockitoBean private MemberUtil memberUtil;
@@ -108,7 +111,7 @@ class MemberServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 아이디_중복_확인_시 {
+    class 아이디_중복을_확인할_때 {
 
         @BeforeEach
         void setUp() {
@@ -146,6 +149,74 @@ class MemberServiceTest extends IntegrationTest {
 
             // when& then
             assertThat(memberService.checkDuplicateClokeyId(request).duplicated()).isTrue();
+        }
+    }
+
+    @Nested
+    class 차단을_토글할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            "testEmail1",
+                            "testClokeyId1",
+                            "testNickname1",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO));
+            Member member2 =
+                    Member.createMember(
+                            "testEmail2",
+                            "testClokeyId2",
+                            "testNickname2",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO));
+
+            memberRepository.saveAll(List.of(member1, member2));
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+        }
+
+        @Test
+        void 차단_상태가_아니라면_차단한다() {
+            // when
+            memberService.toggleBlockStatus(2L);
+
+            // then
+            assertThat(blockRepository.findById(1L).orElseThrow())
+                    .extracting("blocker.id", "blocked.id")
+                    .containsExactly(1L, 2L);
+        }
+
+        @Test
+        void 차단_상태라면_차단을_해제한다() {
+            // given
+            Member blocker = memberRepository.findById(1L).orElseThrow();
+            Member blocked = memberRepository.findById(2L).orElseThrow();
+            Block block = Block.createBlock(blocker, blocked);
+            blockRepository.save(block);
+
+            // when
+            memberService.toggleBlockStatus(2L);
+
+            // then
+            assertThat(
+                            blockRepository.findByBlockerIdAndBlockedId(
+                                    blocker.getId(), blocked.getId()))
+                    .isNotPresent();
+        }
+
+        @Test
+        void 자기_자신을_차단하면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> memberService.toggleBlockStatus(1L))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(MemberErrorCode.SELF_BLOCK_UNAVAILABLE.getMessage());
+        }
+
+        @Test
+        void 차단_대상이_존재하지_않으면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> memberService.toggleBlockStatus(999L))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
         }
     }
 }

--- a/clokey-domain/src/main/java/org/clokey/member/entity/Block.java
+++ b/clokey-domain/src/main/java/org/clokey/member/entity/Block.java
@@ -30,13 +30,13 @@ public class Block {
     @NotNull
     private Member blocked; // 차단된 회원
 
-    //    @Builder(access = AccessLevel.PRIVATE)
-    //    private Block(Member blocker, Member blocked) {
-    //        this.blocker = blocker;
-    //        this.blocked = blocked;
-    //    }
-    //
-    //    public static Block createBlock(Member blocker, Member blocked) {
-    //        return Block.builder().blocker(blocker).blocked(blocked).build();
-    //    }
+    @Builder(access = AccessLevel.PRIVATE)
+    private Block(Member blocker, Member blocked) {
+        this.blocker = blocker;
+        this.blocked = blocked;
+    }
+
+    public static Block createBlock(Member blocker, Member blocked) {
+        return Block.builder().blocker(blocker).blocked(blocked).build();
+    }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #52 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 회원 차단 API 구현

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 회원 차단을 토글로 수정할 수 있는 기능을 구현했습니다.
- 차단 상태면 해제하고, 차단 상태가 아니라면 차단하도록 구현했습니다.
- 혹시 빠뜨린 검증이 있는지 봐주시길 바랍니다.