### PR TITLE
[feat/#58] Presigned URL 관련 유틸리티 함수 구현

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @yongjun0511 @Ssamssamukja @2ghrms @juuuuone
+* @yongjun0511 @Ssamssamukja @2ghrms @juuuuone @dev2yup

--- a/clokey-api/src/main/resources/application-dev.yml
+++ b/clokey-api/src/main/resources/application-dev.yml
@@ -64,6 +64,14 @@ jwt:
   refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}
   issuer: ${JWT_ISSUER}
 
+aws:
+  access-key-id: ${AWS_ACCESS_KEY_ID}
+  secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  region: ${AWS_REGION}
+  s3:
+    bucket: ${S3_BUCKET}
+    endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
+
 swagger:
   username: ${SWAGGER_USERNAME}
   password: ${SWAGGER_PASSWORD}

--- a/clokey-api/src/main/resources/application-local.yml
+++ b/clokey-api/src/main/resources/application-local.yml
@@ -64,6 +64,14 @@ jwt:
   refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}
   issuer: ${JWT_ISSUER}
 
+aws:
+  access-key-id: ${AWS_ACCESS_KEY_ID}
+  secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  region: ${AWS_REGION}
+  s3:
+    bucket: ${S3_BUCKET}
+    endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
+
 spring-doc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/clokey-api/src/main/resources/application-prod.yml
+++ b/clokey-api/src/main/resources/application-prod.yml
@@ -63,3 +63,11 @@ jwt:
   access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME}
   refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}
   issuer: ${JWT_ISSUER}
+
+aws:
+  access-key-id: ${AWS_ACCESS_KEY_ID}
+  secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  region: ${AWS_REGION}
+  s3:
+    bucket: ${S3_BUCKET}
+    endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}

--- a/clokey-infrastructure/build.gradle
+++ b/clokey-infrastructure/build.gradle
@@ -14,4 +14,5 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 }

--- a/clokey-infrastructure/src/main/java/org/clokey/config/S3Config.java
+++ b/clokey-infrastructure/src/main/java/org/clokey/config/S3Config.java
@@ -1,0 +1,35 @@
+package org.clokey.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.RequiredArgsConstructor;
+import org.clokey.properties.AwsProperties;
+import org.clokey.properties.S3Properties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+    private final AwsProperties awsProperties;
+    private final S3Properties s3Properties;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        BasicAWSCredentials credentials =
+                new BasicAWSCredentials(
+                        awsProperties.accessKeyId(), awsProperties.secretAccessKey());
+        AwsClientBuilder.EndpointConfiguration endpointConfiguration =
+                new AwsClientBuilder.EndpointConfiguration(
+                        s3Properties.endpoint(), awsProperties.region());
+
+        return AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(endpointConfiguration)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/clokey-infrastructure/src/main/java/org/clokey/enums/FileExtension.java
+++ b/clokey-infrastructure/src/main/java/org/clokey/enums/FileExtension.java
@@ -1,0 +1,27 @@
+package org.clokey.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FileExtension {
+    PNG("png"),
+    JPG("jpg"),
+    JPEG("jpeg"),
+    WEBP("webp"),
+    HEIC("heic"),
+    HEIF("heif");
+
+    private final String extension;
+
+    @JsonCreator
+    public static FileExtension from(String extension) {
+        return Stream.of(values())
+                .filter(e -> e.name().equalsIgnoreCase(extension))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/clokey-infrastructure/src/main/java/org/clokey/enums/ImageType.java
+++ b/clokey-infrastructure/src/main/java/org/clokey/enums/ImageType.java
@@ -1,0 +1,16 @@
+package org.clokey.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageType {
+    MEMBER_PROFILE("member-profile", "회원 프로필 사진"),
+    MEMBER_BACKGROUND("member-background", "회원 배경 사진"),
+    ClOTH_IMAGE("cloth-image", "옷 사진"),
+    HISTORY_IMAGE("history-image", "기록 사진");
+
+    private final String type;
+    private final String description;
+}

--- a/clokey-infrastructure/src/main/java/org/clokey/properties/AwsProperties.java
+++ b/clokey-infrastructure/src/main/java/org/clokey/properties/AwsProperties.java
@@ -1,0 +1,6 @@
+package org.clokey.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("aws")
+public record AwsProperties(String accessKeyId, String secretAccessKey, String region) {}

--- a/clokey-infrastructure/src/main/java/org/clokey/properties/PropertiesConfig.java
+++ b/clokey-infrastructure/src/main/java/org/clokey/properties/PropertiesConfig.java
@@ -4,5 +4,10 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties({RedisProperties.class, JwtProperties.class})
+@EnableConfigurationProperties({
+    RedisProperties.class,
+    JwtProperties.class,
+    S3Properties.class,
+    AwsProperties.class
+})
 public class PropertiesConfig {}

--- a/clokey-infrastructure/src/main/java/org/clokey/properties/S3Properties.java
+++ b/clokey-infrastructure/src/main/java/org/clokey/properties/S3Properties.java
@@ -1,0 +1,6 @@
+package org.clokey.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("aws.s3")
+public record S3Properties(String bucket, String endpoint) {}

--- a/clokey-infrastructure/src/main/java/org/clokey/util/S3Util.java
+++ b/clokey-infrastructure/src/main/java/org/clokey/util/S3Util.java
@@ -1,0 +1,99 @@
+package org.clokey.util;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.clokey.enums.FileExtension;
+import org.clokey.enums.ImageType;
+import org.clokey.properties.S3Properties;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class S3Util {
+
+    private final AmazonS3 amazonS3;
+    private final S3Properties s3Properties;
+
+    public String createPresignedUrl(
+            ImageType imageType, Long targetId, FileExtension fileExtension, String md5Hash) {
+        String imageKey = UUID.randomUUID().toString();
+        String fileName = createFileName(imageType, targetId, imageKey, fileExtension);
+        String bucket = s3Properties.bucket();
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                generatePresignedUrlRequest(
+                        bucket, fileName, fileExtension.getExtension(), md5Hash);
+
+        return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+    }
+
+    private String createFileName(
+            ImageType imageType, Long memberId, String imageKey, FileExtension fileExtension) {
+        return memberId
+                + "/"
+                + imageType.getType()
+                + "/"
+                + imageKey
+                + "."
+                + fileExtension.getExtension();
+    }
+
+    private GeneratePresignedUrlRequest generatePresignedUrlRequest(
+            String bucket, String fileName, String imageFileExtension, String md5Hash) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileName, HttpMethod.PUT)
+                        .withKey(fileName)
+                        .withContentType("image/" + imageFileExtension)
+                        .withExpiration(getPresignedUrlExpiration());
+
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        generatePresignedUrlRequest.addRequestParameter(Headers.CONTENT_MD5, md5Hash);
+
+        return generatePresignedUrlRequest;
+    }
+
+    public void deleteAllByUrls(List<String> urls) {
+        String bucket = s3Properties.bucket();
+
+        List<DeleteObjectsRequest.KeyVersion> keys =
+                urls.stream()
+                        .map(this::extractObjectKey)
+                        .map(DeleteObjectsRequest.KeyVersion::new)
+                        .toList();
+
+        DeleteObjectsRequest request = new DeleteObjectsRequest(bucket).withKeys(keys);
+        amazonS3.deleteObjects(request);
+    }
+
+    public void deleteByUrl(String url) {
+        String bucket = s3Properties.bucket();
+        String objectKey = extractObjectKey(url);
+        amazonS3.deleteObject(bucket, objectKey);
+    }
+
+    private String extractObjectKey(String url) {
+        String bucket = s3Properties.bucket();
+        int idx = url.indexOf(bucket) + bucket.length() + 1;
+        return url.substring(idx);
+    }
+
+    private Date getPresignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += TimeUnit.MINUTES.toMillis(1);
+        expiration.setTime(expTimeMillis);
+
+        return expiration;
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #58 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- Presigned URL 관련 유틸리티 함수 구현

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- PresignedURL을 발급 받는 메서드를 구현했습니다.
- 주소 생성 원리는 {memberId}/{ImageType}/{UUID}.{FileExtension}입니다.
- Prefix에 memberId를 넣은 이유는 나중에 이미지 생성 전에 엔티티가 생성되는 것이 멤버밖에 없고.. ( 기록이나 옷은 생성할 때 이미 주소가 필요하니... Presigned URL은 기록과 옷 생성 API 이전에 호출됩니다)
- 나중에 맨 앞에 prefix를 통해서 멤버와 관련된 모든 사진을 삭제하기 편리하기 때문입니다.
- 추가적으로 url을 바탕으로 batch 삭제와 단일 url 삭제 로직을 넣었습니다.
- ⭐ MD5 해시를 바탕으로 프론트가 사진이 똑바로 업로드가 되었는지 확인하는 구조입니다. -> 별도의 이미지 업로드 완료 API는 만들지 않기 위함.

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
- 새로 오신 분을 CODEOWNER와 Reviewers 변수에 추가했습니다. (바로 적용이 안될수는 있음)
- Infra의 영역이라 테스트 코드 작성은 안했지만, 나중에 이미지 발급 API에서 테스트 코드 추가하겠습니다.