### PR TITLE
[fix/#69] S3 Utils 문제 & 양방향 삭제 로직 제거

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/comment/repository/ReplyRepository.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/repository/ReplyRepository.java
@@ -2,5 +2,13 @@ package org.clokey.domain.comment.repository;
 
 import org.clokey.comment.entitiy.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface ReplyRepository extends JpaRepository<Reply, Long>, ReplyRepositoryCustom {}
+public interface ReplyRepository extends JpaRepository<Reply, Long>, ReplyRepositoryCustom {
+
+    @Modifying
+    @Query("delete from Reply r where r.comment.id = :commentId")
+    void deleteByCommentId(@Param("commentId") Long commentId);
+}

--- a/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/comment/service/CommentServiceImpl.java
@@ -123,6 +123,7 @@ public class CommentServiceImpl implements CommentService {
 
         validateCommentOwner(currentMember, comment);
 
+        replyRepository.deleteByCommentId(comment.getId());
         commentRepository.delete(comment);
     }
 

--- a/clokey-domain/src/main/java/org/clokey/cloth/entity/Cloth.java
+++ b/clokey-domain/src/main/java/org/clokey/cloth/entity/Cloth.java
@@ -2,9 +2,13 @@ package org.clokey.cloth.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.*;
 import org.clokey.category.entity.Category;
 import org.clokey.common.model.BaseEntity;
+import org.clokey.folder.entity.ClothFolder;
+import org.clokey.history.entity.HistoryCloth;
 import org.clokey.member.entity.Member;
 
 @Entity
@@ -52,9 +56,9 @@ public class Cloth extends BaseEntity {
                 .build();
     }
 
-    //    @OneToMany(mappedBy = "cloth", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<HistoryCloth> historyClothes = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "cloth", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<ClothFolder> clothFolders = new ArrayList<>();
+    @OneToMany(mappedBy = "cloth")
+    private List<HistoryCloth> historyClothes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "cloth")
+    private List<ClothFolder> clothFolders = new ArrayList<>();
 }

--- a/clokey-domain/src/main/java/org/clokey/comment/entitiy/Comment.java
+++ b/clokey-domain/src/main/java/org/clokey/comment/entitiy/Comment.java
@@ -34,7 +34,7 @@ public class Comment extends BaseEntity {
     @NotNull
     private History history;
 
-    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "comment")
     private List<Reply> replies = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/clokey-domain/src/main/java/org/clokey/coordinate/entity/Coordinate.java
+++ b/clokey-domain/src/main/java/org/clokey/coordinate/entity/Coordinate.java
@@ -39,7 +39,7 @@ public class Coordinate extends BaseEntity {
     @NotNull
     private Member member;
 
-    @OneToMany(mappedBy = "coordinate", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "coordinate")
     private List<CoordinateCloth> coordinateClothes = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/clokey-domain/src/main/java/org/clokey/folder/entity/ClothFolder.java
+++ b/clokey-domain/src/main/java/org/clokey/folder/entity/ClothFolder.java
@@ -25,13 +25,13 @@ public class ClothFolder extends BaseEntity {
     @NotNull
     private Folder folder;
 
-    //    @Builder(access = AccessLevel.PRIVATE)
-    //    private ClothFolder(Cloth cloth, Folder folder) {
-    //        this.cloth = cloth;
-    //        this.folder = folder;
-    //    }
-    //
-    //    public static ClothFolder createClothFolder(Cloth cloth, Folder folder) {
-    //        return ClothFolder.builder().cloth(cloth).folder(folder).build();
-    //    }
+    @Builder(access = AccessLevel.PRIVATE)
+    private ClothFolder(Cloth cloth, Folder folder) {
+        this.cloth = cloth;
+        this.folder = folder;
+    }
+
+    public static ClothFolder createClothFolder(Cloth cloth, Folder folder) {
+        return ClothFolder.builder().cloth(cloth).folder(folder).build();
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/folder/entity/Folder.java
+++ b/clokey-domain/src/main/java/org/clokey/folder/entity/Folder.java
@@ -2,6 +2,8 @@ package org.clokey.folder.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.*;
 import org.clokey.common.model.BaseEntity;
 import org.clokey.member.entity.Member;
@@ -24,6 +26,6 @@ public class Folder extends BaseEntity {
     @NotNull
     private Member member;
 
-    //    @OneToMany(mappedBy = "folder", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<ClothFolder> clothFolders = new ArrayList<>();
+    @OneToMany(mappedBy = "folder")
+    private List<ClothFolder> clothFolders = new ArrayList<>();
 }

--- a/clokey-domain/src/main/java/org/clokey/history/entity/Hashtag.java
+++ b/clokey-domain/src/main/java/org/clokey/history/entity/Hashtag.java
@@ -18,12 +18,12 @@ public class Hashtag extends BaseEntity {
     @NotNull
     private String name;
 
-    //    @Builder(access = AccessLevel.PRIVATE)
-    //    private Hashtag(String name) {
-    //        this.name = name;
-    //    }
-    //
-    //    public static Hashtag createHashtag(String name) {
-    //        return Hashtag.builder().name(name).build();
-    //    }
+    @Builder(access = AccessLevel.PRIVATE)
+    private Hashtag(String name) {
+        this.name = name;
+    }
+
+    public static Hashtag createHashtag(String name) {
+        return Hashtag.builder().name(name).build();
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/history/entity/HashtagHistory.java
+++ b/clokey-domain/src/main/java/org/clokey/history/entity/HashtagHistory.java
@@ -30,13 +30,13 @@ public class HashtagHistory extends BaseEntity {
     @NotNull
     private History history;
 
-    //    @Builder(access = AccessLevel.PRIVATE)
-    //    private HashtagHistory(Hashtag hashtag, History history) {
-    //        this.hashtag = hashtag;
-    //        this.history = history;
-    //    }
-    //
-    //    public static HashtagHistory createHashtagHistory(Hashtag hashtag, History history) {
-    //        return HashtagHistory.builder().hashtag(hashtag).history(history).build();
-    //    }
+    @Builder(access = AccessLevel.PRIVATE)
+    private HashtagHistory(Hashtag hashtag, History history) {
+        this.hashtag = hashtag;
+        this.history = history;
+    }
+
+    public static HashtagHistory createHashtagHistory(Hashtag hashtag, History history) {
+        return HashtagHistory.builder().hashtag(hashtag).history(history).build();
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/history/entity/HistoryCloth.java
+++ b/clokey-domain/src/main/java/org/clokey/history/entity/HistoryCloth.java
@@ -2,6 +2,8 @@ package org.clokey.history.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.*;
 import org.clokey.cloth.entity.Cloth;
 import org.clokey.common.model.BaseEntity;
@@ -32,16 +34,16 @@ public class HistoryCloth extends BaseEntity {
     @NotNull
     private Cloth cloth;
 
-    //    @OneToMany(mappedBy = "historyCloth", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<HistoryClothTag> clothTags = new ArrayList<>();
+    @OneToMany(mappedBy = "historyCloth")
+    private List<HistoryClothTag> clothTags = new ArrayList<>();
 
-    //    @Builder(access = AccessLevel.PRIVATE)
-    //    private HistoryCloth(History history, Cloth cloth) {
-    //        this.history = history;
-    //        this.cloth = cloth;
-    //    }
-    //
-    //    public static HistoryCloth createHistoryCloth(History history, Cloth cloth) {
-    //        return HistoryCloth.builder().history(history).cloth(cloth).build();
-    //    }
+    @Builder(access = AccessLevel.PRIVATE)
+    private HistoryCloth(History history, Cloth cloth) {
+        this.history = history;
+        this.cloth = cloth;
+    }
+
+    public static HistoryCloth createHistoryCloth(History history, Cloth cloth) {
+        return HistoryCloth.builder().history(history).cloth(cloth).build();
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/history/entity/HistoryImage.java
+++ b/clokey-domain/src/main/java/org/clokey/history/entity/HistoryImage.java
@@ -2,6 +2,8 @@ package org.clokey.history.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.*;
 import org.clokey.common.model.BaseEntity;
 
@@ -21,16 +23,16 @@ public class HistoryImage extends BaseEntity {
     @NotNull
     private History history;
 
-    //    @OneToMany(mappedBy = "historyImage", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<HistoryClothTag> clothTags = new ArrayList<>();
+    @OneToMany(mappedBy = "historyImage")
+    private List<HistoryClothTag> clothTags = new ArrayList<>();
 
-    //    @Builder(access = AccessLevel.PRIVATE)
-    //    private HistoryImage(String imageUrl, History history) {
-    //        this.imageUrl = imageUrl;
-    //        this.history = history;
-    //    }
-    //
-    //    public static HistoryImage createHistoryImage(String imageUrl, History history) {
-    //        return HistoryImage.builder().imageUrl(imageUrl).history(history).build();
-    //    }
+    @Builder(access = AccessLevel.PRIVATE)
+    private HistoryImage(String imageUrl, History history) {
+        this.imageUrl = imageUrl;
+        this.history = history;
+    }
+
+    public static HistoryImage createHistoryImage(String imageUrl, History history) {
+        return HistoryImage.builder().imageUrl(imageUrl).history(history).build();
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/like/entity/MemberLike.java
+++ b/clokey-domain/src/main/java/org/clokey/like/entity/MemberLike.java
@@ -33,13 +33,13 @@ public class MemberLike extends BaseEntity {
     @NotNull
     private History history;
 
-    //    @Builder(access = AccessLevel.PRIVATE)
-    //    private MemberLike(Member member, History history) {
-    //        this.member = member;
-    //        this.history = history;
-    //    }
-    //
-    //    public static MemberLike createMemberLike(Member member, History history) {
-    //        return MemberLike.builder().member(member).history(history).build();
-    //    }
+    @Builder(access = AccessLevel.PRIVATE)
+    private MemberLike(Member member, History history) {
+        this.member = member;
+        this.history = history;
+    }
+
+    public static MemberLike createMemberLike(Member member, History history) {
+        return MemberLike.builder().member(member).history(history).build();
+    }
 }

--- a/clokey-domain/src/main/java/org/clokey/lookbook/entity/LookBook.java
+++ b/clokey-domain/src/main/java/org/clokey/lookbook/entity/LookBook.java
@@ -28,7 +28,7 @@ public class LookBook extends BaseEntity {
     @NotNull
     private Member member;
 
-    @OneToMany(mappedBy = "lookBook", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "lookBook")
     private List<Coordinate> codies = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/clokey-domain/src/main/java/org/clokey/member/entity/Member.java
+++ b/clokey-domain/src/main/java/org/clokey/member/entity/Member.java
@@ -3,14 +3,24 @@ package org.clokey.member.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.clokey.cloth.entity.Cloth;
+import org.clokey.comment.entitiy.Comment;
+import org.clokey.comment.entitiy.Reply;
 import org.clokey.common.model.BaseEntity;
+import org.clokey.folder.entity.Folder;
+import org.clokey.history.entity.History;
+import org.clokey.like.entity.MemberLike;
 import org.clokey.member.enums.MemberRole;
 import org.clokey.member.enums.MemberStatus;
 import org.clokey.member.enums.Visibility;
+import org.clokey.notification.entity.ClokeyNotification;
+import org.clokey.term.entity.MemberTerm;
 
 @Getter
 @Entity
@@ -55,39 +65,38 @@ public class Member extends BaseEntity {
 
     private LocalDate inactiveDate;
 
-    //
-    //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    //    private List<MemberTerm> memberTermList = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    //    private List<ClokeyNotification> clokeyNotifications = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "followFrom", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<Follow> followFroms = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "followTo", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<Follow> followTos = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<Comment> comments = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<Folder> folders = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<MemberLike> memberLikes = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    //    private List<Reply> replies = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    //    private List<MemberLike> memberLikeList = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    //    private List<Cloth> clothList = new ArrayList<>();
-    //
-    //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    //    private List<History> historyList = new ArrayList<>();
+    @OneToMany(mappedBy = "member")
+    private List<MemberTerm> memberTermList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<ClokeyNotification> clokeyNotifications = new ArrayList<>();
+
+    @OneToMany(mappedBy = "followFrom")
+    private List<Follow> followFroms = new ArrayList<>();
+
+    @OneToMany(mappedBy = "followTo")
+    private List<Follow> followTos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<Folder> folders = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<MemberLike> memberLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<Reply> replies = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<MemberLike> memberLikeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<Cloth> clothList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<History> historyList = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Member(

--- a/clokey-domain/src/main/java/org/clokey/notification/entity/ClokeyNotification.java
+++ b/clokey-domain/src/main/java/org/clokey/notification/entity/ClokeyNotification.java
@@ -39,35 +39,35 @@ public class ClokeyNotification extends BaseEntity {
     @NotNull
     private Member member;
 
-    //    @Builder(access = AccessLevel.PRIVATE)
-    //    private ClokeyNotification(
-    //            Member member,
-    //            String content,
-    //            String notificationImageUrl,
-    //            String redirectInfo,
-    //            RedirectType redirectType,
-    //            ReadStatus readStatus) {
-    //        this.member = member;
-    //        this.content = content;
-    //        this.notificationImageUrl = notificationImageUrl;
-    //        this.redirectInfo = redirectInfo;
-    //        this.redirectType = redirectType;
-    //        this.readStatus = readStatus;
-    //    }
-    //
-    //    public static ClokeyNotification createClokeyNotification(
-    //            Member member,
-    //            String content,
-    //            String notificationImageUrl,
-    //            String redirectInfo,
-    //            RedirectType redirectType) {
-    //        return ClokeyNotification.builder()
-    //                .member(member)
-    //                .content(content)
-    //                .notificationImageUrl(notificationImageUrl)
-    //                .redirectInfo(redirectInfo)
-    //                .redirectType(redirectType)
-    //                .readStatus(ReadStatus.NOT_READ)
-    //                .build();
-    //    }
+    @Builder(access = AccessLevel.PRIVATE)
+    private ClokeyNotification(
+            Member member,
+            String content,
+            String notificationImageUrl,
+            String redirectInfo,
+            RedirectType redirectType,
+            ReadStatus readStatus) {
+        this.member = member;
+        this.content = content;
+        this.notificationImageUrl = notificationImageUrl;
+        this.redirectInfo = redirectInfo;
+        this.redirectType = redirectType;
+        this.readStatus = readStatus;
+    }
+
+    public static ClokeyNotification createClokeyNotification(
+            Member member,
+            String content,
+            String notificationImageUrl,
+            String redirectInfo,
+            RedirectType redirectType) {
+        return ClokeyNotification.builder()
+                .member(member)
+                .content(content)
+                .notificationImageUrl(notificationImageUrl)
+                .redirectInfo(redirectInfo)
+                .redirectType(redirectType)
+                .readStatus(ReadStatus.NOT_READ)
+                .build();
+    }
 }

--- a/clokey-infrastructure/src/main/java/org/clokey/util/S3Util.java
+++ b/clokey-infrastructure/src/main/java/org/clokey/util/S3Util.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.clokey.enums.FileExtension;
 import org.clokey.enums.ImageType;
 import org.clokey.properties.S3Properties;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class S3Util {
 
     private final AmazonS3 amazonS3;
@@ -58,12 +60,16 @@ public class S3Util {
         generatePresignedUrlRequest.addRequestParameter(
                 Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
 
-        generatePresignedUrlRequest.addRequestParameter(Headers.CONTENT_MD5, md5Hash);
+        generatePresignedUrlRequest.setContentMd5(md5Hash);
 
         return generatePresignedUrlRequest;
     }
 
     public void deleteAllByUrls(List<String> urls) {
+        if (urls == null || urls.isEmpty()) {
+            log.info("deleteAllByUrls skipped: received null or empty urls");
+            return;
+        }
         String bucket = s3Properties.bucket();
 
         List<DeleteObjectsRequest.KeyVersion> keys =
@@ -83,9 +89,8 @@ public class S3Util {
     }
 
     private String extractObjectKey(String url) {
-        String bucket = s3Properties.bucket();
-        int idx = url.indexOf(bucket) + bucket.length() + 1;
-        return url.substring(idx);
+        int comIndex = url.indexOf(".com/");
+        return url.substring(comIndex + 5);
     }
 
     private Date getPresignedUrlExpiration() {

--- a/documentation/feature/도메인 수정과 Flyway 사용법.md
+++ b/documentation/feature/도메인 수정과 Flyway 사용법.md
@@ -11,7 +11,7 @@
 - key값
 - 필드
 - 단방향 매핑
-- 양방향 매핑 (양방향도 싹다 달아주세요)
+- 양방향 매핑 (양방향도 싹다 달아주세요. 단, Cascade 삭제는 사용하지 않습니다! -> JPQL 삭제와 deletAllInBatch만 사용할 것.)
 
 ### ✅코드 예시 → 생성 방법
 
@@ -32,22 +32,22 @@ public class Album extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private AlbumPlan plan;
 
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "album")
     private List<Payment> payments = new ArrayList<>();
 
-    @OneToOne(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "album")
     private Subscription subscription;
 
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "album")
     private List<Event> events = new ArrayList<>();
 
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "album")
     private List<Participant> participants = new ArrayList<>();
 
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "album")
     private List<Favorites> favorites = new ArrayList<>();
 
-    @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "album")
     private List<Image> images = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #69 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 이번 PR은 수정 내용이 많다기 보다는 숙지하셔야 할 내용이 많습니다.... 😢 

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
### S3 Util 관련 변화 (이해할 필요까지는 없습니다)
- Key 추출을 잘 못해서 삭제되는 로직이 수정되었어요.
- MD5 해시가 content로 들어 가야하는 부분이 수정되었어요.
- delete 로직에 로그를 추가했어요 ( 추후에 비동기 처리할거라 실패해도 API 자체는 성공하기 때문에.. 추후 PR에서 다루겠습니다.)

### 중요 : 삭제 로직 변경
앞으로 양방향 매핑을 통한 Cascade 삭제를 활용하지 않을 예정입니다. 
삭제할 엔티티들을 모두 조회해온 뒤 하나씩 삭제하기 때문입니다.
-  대신 deleteAllInBatch와 JPQL + @Modifying을 통한 삭제를 활용합니다. (삭제에서 동시성 문제도 해결 됨. 해당 쿼리들은 조회를 하지 않기 때문)

그렇지만, 양방향 메서드의 편의성 자체를 활용하는 것은 상관이 없기 때문에 유지는 하겠습니다.
- 양방향 자체는 살려놨으며 cascade만 삭제했습니다.
- 추후에  CascadeType.PERSIST 정도는 해볼만 합니다. (부모 저장하면 자식까지 모두 저장)

요약하자면 위와 같은 방향으로 진행할 예정이고 원리와 Why는 블로그에 정리했습니다. (궁금하시면 보세요.)
- 양방향 삭제를 사용하지 않게 된 이유 : https://coding-self-study.tistory.com/31
- @Modifying을 저렇게 사용하기로 생각한 이유 : https://coding-self-study.tistory.com/32