### PR TITLE
[Feat/#72] 본인 확인 API 구현

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/member/controller/MemberController.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package org.clokey.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.clokey.code.GlobalBaseSuccessCode;
 import org.clokey.domain.member.dto.request.DuplicatedIdCheckRequest;
 import org.clokey.domain.member.dto.request.ProfileUpdateRequest;
 import org.clokey.domain.member.dto.response.DuplicatedIdCheckResponse;
+import org.clokey.domain.member.dto.response.MyselfCheckResponse;
 import org.clokey.domain.member.service.MemberService;
 import org.clokey.response.BaseResponse;
 import org.springframework.validation.annotation.Validated;
@@ -43,5 +45,14 @@ public class MemberController {
     public BaseResponse<Void> toggleBlockStatus(@PathVariable Long memberId) {
         memberService.toggleBlockStatus(memberId);
         return BaseResponse.onSuccess(GlobalBaseSuccessCode.NO_CONTENT, null);
+    }
+
+    @GetMapping("check-myself")
+    @Operation(summary = "본인인지 여부 확인", description = "클로키 아이디로 본인인지 확인합니다.")
+    public BaseResponse<MyselfCheckResponse> checkIsMySelf(
+            @Parameter(description = "본인인지 확인할 클로키 ID") @RequestParam("clokeyId") String clokeyId) {
+
+        return BaseResponse.onSuccess(
+                GlobalBaseSuccessCode.OK, memberService.checkIsMyself(clokeyId));
     }
 }

--- a/clokey-api/src/main/java/org/clokey/domain/member/dto/response/MyselfCheckResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/dto/response/MyselfCheckResponse.java
@@ -1,0 +1,10 @@
+package org.clokey.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyselfCheckResponse(
+        @Schema(description = "본인 여부", example = "true") boolean isMyself) {
+    public static MyselfCheckResponse of(boolean isMyself) {
+        return new MyselfCheckResponse(isMyself);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/member/exception/MemberErrorCode.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/exception/MemberErrorCode.java
@@ -11,7 +11,8 @@ public enum MemberErrorCode implements BaseErrorCode {
     BANNED_MEMBER_TO_PUBLIC(400, "MEMBER_4001", "신고당한 회원은 공개로 전환할 수 없습니다."),
     SELF_BLOCK_UNAVAILABLE(400, "MEMBER_4002", "자기 자신을 차단할 수 없습니다"),
 
-    MEMBER_NOT_FOUND(404, "MEMBER_4041", "해당 회원을 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(404, "MEMBER_4041", "해당 회원을 찾을 수 없습니다."),
+    CLOKEY_ID_NOT_FOUND(404, "MEMBER_4042", "해당 클로키 아이디를 찾을 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package org.clokey.domain.member.service;
 import org.clokey.domain.member.dto.request.DuplicatedIdCheckRequest;
 import org.clokey.domain.member.dto.request.ProfileUpdateRequest;
 import org.clokey.domain.member.dto.response.DuplicatedIdCheckResponse;
+import org.clokey.domain.member.dto.response.MyselfCheckResponse;
 
 public interface MemberService {
 
@@ -11,4 +12,6 @@ public interface MemberService {
     DuplicatedIdCheckResponse checkDuplicateClokeyId(DuplicatedIdCheckRequest request);
 
     void toggleBlockStatus(Long memberId);
+
+    MyselfCheckResponse checkIsMyself(String clokeyId);
 }

--- a/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/member/service/MemberServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.clokey.domain.member.dto.request.DuplicatedIdCheckRequest;
 import org.clokey.domain.member.dto.request.ProfileUpdateRequest;
 import org.clokey.domain.member.dto.response.DuplicatedIdCheckResponse;
+import org.clokey.domain.member.dto.response.MyselfCheckResponse;
 import org.clokey.domain.member.exception.MemberErrorCode;
 import org.clokey.domain.member.repository.BlockRepository;
 import org.clokey.domain.member.repository.MemberRepository;
@@ -76,6 +77,16 @@ public class MemberServiceImpl implements MemberService {
         }
     }
 
+    @Override
+    public MyselfCheckResponse checkIsMyself(String clokeyId) {
+        validateExistsClokeyId(clokeyId);
+        Member currentMember = memberUtil.getCurrentMember();
+
+        boolean isMyself = currentMember.getClokeyId().equals(clokeyId);
+
+        return MyselfCheckResponse.of(isMyself);
+    }
+
     private void validateVisualizeBannedMember(Member member, ProfileUpdateRequest request) {
         boolean banned = member.getMemberStatus().equals(MemberStatus.BANNED);
         boolean changeToPublic = request.visibility().equals(Visibility.PUBLIC);
@@ -87,6 +98,12 @@ public class MemberServiceImpl implements MemberService {
     private void validateSelfBlock(Long blockerId, Long blockedId) {
         if (blockerId.equals(blockedId)) {
             throw new BaseCustomException(MemberErrorCode.SELF_BLOCK_UNAVAILABLE);
+        }
+    }
+
+    private void validateExistsClokeyId(String clokeyId) {
+        if (!memberRepository.existsByClokeyId(clokeyId)) {
+            throw new BaseCustomException(MemberErrorCode.CLOKEY_ID_NOT_FOUND);
         }
     }
 

--- a/clokey-api/src/test/java/org/clokey/domain/member/controller/MemberControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/member/controller/MemberControllerTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.clokey.domain.member.dto.request.DuplicatedIdCheckRequest;
 import org.clokey.domain.member.dto.request.ProfileUpdateRequest;
 import org.clokey.domain.member.dto.response.DuplicatedIdCheckResponse;
+import org.clokey.domain.member.dto.response.MyselfCheckResponse;
 import org.clokey.domain.member.service.MemberService;
 import org.clokey.member.enums.Visibility;
 import org.junit.jupiter.api.Nested;
@@ -244,6 +245,29 @@ class MemberControllerTest {
                     .andExpect(jsonPath("$.isSuccess").value(true))
                     .andExpect(jsonPath("$.code").value("COMMON204"))
                     .andExpect(jsonPath("$.message").value("요청 성공 및 반환값 없음"));
+        }
+    }
+
+    @Nested
+    class 본인_확인_요청_시 {
+
+        @Test
+        void 유효한_요청이면_본인인지_여부를_반환한다() throws Exception {
+            // given
+            String clokeyId = "test123";
+            MyselfCheckResponse response = new MyselfCheckResponse(true);
+
+            given(memberService.checkIsMyself(clokeyId)).willReturn(response);
+
+            // when
+            ResultActions perform =
+                    mockMvc.perform(get("/users/check-myself").param("clokeyId", clokeyId));
+
+            // then
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("COMMON200"))
+                    .andExpect(jsonPath("$.message").value("성공입니다."))
+                    .andExpect(jsonPath("$.result.isMyself").value(true));
         }
     }
 }

--- a/clokey-api/src/test/java/org/clokey/domain/member/service/MemberServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/member/service/MemberServiceTest.java
@@ -9,6 +9,7 @@ import org.clokey.IntegrationTest;
 import org.clokey.TransactionUtil;
 import org.clokey.domain.member.dto.request.DuplicatedIdCheckRequest;
 import org.clokey.domain.member.dto.request.ProfileUpdateRequest;
+import org.clokey.domain.member.dto.response.MyselfCheckResponse;
 import org.clokey.domain.member.exception.MemberErrorCode;
 import org.clokey.domain.member.repository.BlockRepository;
 import org.clokey.domain.member.repository.MemberRepository;
@@ -217,6 +218,43 @@ class MemberServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> memberService.toggleBlockStatus(999L))
                     .isInstanceOf(BaseCustomException.class)
                     .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class 본인인지_확인할_때 {
+
+        @BeforeEach
+        void setUp() {
+            Member member1 =
+                    Member.createMember(
+                            "testEmail1",
+                            "testClokeyId1",
+                            "testNickname1",
+                            OauthInfo.createOauthInfo("testOauthId", OauthProvider.KAKAO));
+            memberRepository.save(member1);
+
+            given(memberUtil.getCurrentMember()).willReturn(member1);
+        }
+
+        @Test
+        void 유효한_요청이면_본인_여부를_반환한다() {
+            // given
+            String clokeyId = "testClokeyId1";
+
+            // when
+            MyselfCheckResponse response = memberService.checkIsMyself(clokeyId);
+
+            // then
+            assertThat(response.isMyself()).isEqualTo(true);
+        }
+
+        @Test
+        void 클로키_아이디가_존재하지_않으면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> memberService.checkIsMyself("WrongId"))
+                    .isInstanceOf(BaseCustomException.class)
+                    .hasMessage("해당 클로키 아이디를 찾을 수 없습니다.");
         }
     }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #72 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
본인확인 API 구현

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 클로키 ID를 받아서 본인(current member)의 ID인지 여부를 반환(boolean)
- 받은 클로키 ID가 존재하지 않으면 예외

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
- 전 회의에서 변수 명이나 설명에 clokey 들어가 있는 부분 codive로 수정해야 한다는 이야기가 있었지만 이번건 아직 clokey로 해놨습니다.
- 본인 확인 기능은 정확히 어떤 상황에서 사용되는 건지 궁금하네용