### PR TITLE
[feat/#106] presignedUrl 발급 로직 수정 & 검증 로직 추가

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/cloth/repository/ClothRepositoryImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/repository/ClothRepositoryImpl.java
@@ -11,9 +11,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.clokey.cloth.entity.Cloth;
 import org.clokey.cloth.enums.Season;
-import org.clokey.domain.cloth.dto.response.ClothListResponse;
 import org.clokey.domain.cloth.dto.response.ClothRecommendListResponse;
-import org.clokey.global.paging.SortDirection;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -24,18 +22,17 @@ import org.springframework.stereotype.Repository;
 public class ClothRepositoryImpl implements ClothRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final ClothRepository clothRepository;
 
     @Override
-    public Slice<ClothRecommendListResponse> findAllMemberRecommendClothesByCategoryAndSeason(
-            Long lastClothId, int size, Long categoryId, Long memberId, Season season) {
+    public Slice<ClothRecommendListResponse> findAllClothesByCategoryAndSeason(
+            Long lastClothId, int size, Long categoryId, Season season) {
 
         Season nextSeason = season.next();
         Season previousSeason = season.previous();
         Season oppositeSeason = season.next().next();
 
-        // 우선 순위에 맞게 페이징 합니다.
-        // - Category는 고정입니다.
-        // - 계절은 요청한 계절에 가까운 순서대로 페이징을 진행합니다.
+        /** 우선 순위에 맞게 페이징 합니다. - Category는 고정입니다. - 계절은 요청한 계절에 가까운 순서대로 페이징을 진행합니다. */
         NumberExpression<Integer> seasonPriority =
                 new CaseBuilder()
                         .when(cloth.season.eq(season))
@@ -56,7 +53,6 @@ public class ClothRepositoryImpl implements ClothRepositoryCustom {
                         .from(cloth)
                         .where(
                                 cloth.category.id.eq(categoryId),
-                                cloth.member.id.eq(memberId),
                                 cloth.season.in(season, nextSeason, previousSeason, oppositeSeason),
                                 lastClothIdCondition(
                                         lastClothId,
@@ -72,60 +68,6 @@ public class ClothRepositoryImpl implements ClothRepositoryCustom {
         return checkLastPage(size, results);
     }
 
-    @Override
-    public Slice<ClothListResponse> findAllMemberClothesByCategoriesAndSeasons(
-            Long lastClothId,
-            int size,
-            SortDirection direction,
-            List<Long> categoryIds,
-            Long memberId,
-            List<Season> seasons) {
-
-        List<ClothListResponse> results =
-                queryFactory
-                        .select(
-                                Projections.constructor(
-                                        ClothListResponse.class,
-                                        cloth.id,
-                                        cloth.clothImageUrl,
-                                        cloth.brand,
-                                        cloth.name))
-                        .from(cloth)
-                        .where(
-                                cloth.member.id.eq(memberId),
-                                categoryFilter(categoryIds),
-                                seasonsFilter(seasons),
-                                lastClothIdCursor(lastClothId, direction))
-                        .orderBy(direction == SortDirection.DESC ? cloth.id.desc() : cloth.id.asc())
-                        .limit((long) size + 1)
-                        .fetch();
-
-        return checkLastPage(size, results);
-    }
-
-    private BooleanExpression categoryFilter(List<Long> categoryIds) {
-        if (categoryIds == null || categoryIds.isEmpty()) {
-            return null;
-        }
-        return cloth.category.id.in(categoryIds);
-    }
-
-    private BooleanExpression seasonsFilter(List<Season> seasons) {
-        if (seasons == null || seasons.isEmpty()) {
-            return null;
-        }
-        return cloth.season.in(seasons);
-    }
-
-    private BooleanExpression lastClothIdCursor(Long lastClothId, SortDirection direction) {
-        if (lastClothId == null) {
-            return null;
-        }
-        return direction == SortDirection.DESC
-                ? cloth.id.lt(lastClothId)
-                : cloth.id.gt(lastClothId);
-    }
-
     private BooleanExpression lastClothIdCondition(
             Long lastClothId,
             Season season,
@@ -137,11 +79,8 @@ public class ClothRepositoryImpl implements ClothRepositoryCustom {
             return null;
         }
 
-        Cloth lastCloth = queryFactory.selectFrom(cloth).where(cloth.id.eq(lastClothId)).fetchOne();
-
-        if (lastCloth == null) {
-            return null;
-        }
+        // 마지막 항목의 Cloth 조회
+        Cloth lastCloth = clothRepository.findById(lastClothId).orElseThrow();
 
         int lastPriority =
                 calculateSeasonPriority(

--- a/clokey-api/src/test/java/org/clokey/domain/cloth/service/ClothServiceTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/cloth/service/ClothServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import java.util.List;
-import java.util.stream.Stream;
 import org.clokey.IntegrationTest;
 import org.clokey.category.entity.Category;
 import org.clokey.cloth.entity.Cloth;
@@ -14,16 +13,10 @@ import org.clokey.domain.category.exception.CategoryErrorCode;
 import org.clokey.domain.category.repository.CategoryRepository;
 import org.clokey.domain.cloth.dto.request.ClothCreateRequest;
 import org.clokey.domain.cloth.dto.request.ClothCreateRequests;
-import org.clokey.domain.cloth.dto.request.ClothUpdateRequest;
-import org.clokey.domain.cloth.dto.response.ClothDetailsResponse;
-import org.clokey.domain.cloth.dto.response.ClothListResponse;
 import org.clokey.domain.cloth.dto.response.ClothRecommendListResponse;
-import org.clokey.domain.cloth.exception.ClothErrorCode;
 import org.clokey.domain.cloth.repository.ClothRepository;
-import org.clokey.domain.image.event.ImageDeleteEvent;
 import org.clokey.domain.member.repository.MemberRepository;
 import org.clokey.exception.BaseCustomException;
-import org.clokey.global.paging.SortDirection;
 import org.clokey.global.util.MemberUtil;
 import org.clokey.member.entity.Member;
 import org.clokey.member.entity.OauthInfo;
@@ -33,16 +26,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.event.ApplicationEvents;
-import org.springframework.test.context.event.RecordApplicationEvents;
 
-@RecordApplicationEvents
 class ClothServiceTest extends IntegrationTest {
 
     @Autowired private ClothService clothService;
@@ -51,7 +37,6 @@ class ClothServiceTest extends IntegrationTest {
     @Autowired private CategoryRepository categoryRepository;
 
     @MockitoBean private MemberUtil memberUtil;
-    @Autowired private ApplicationEvents applicationEvents;
 
     @Nested
     class 옷을_생성할_때 {
@@ -68,9 +53,8 @@ class ClothServiceTest extends IntegrationTest {
             memberRepository.save(member);
             given(memberUtil.getCurrentMember()).willReturn(member);
 
-            Category parentCategory = Category.createCategory("testParentCategory", null);
-            Category category = Category.createCategory("testCategory", parentCategory);
-            categoryRepository.saveAll(List.of(parentCategory, category));
+            Category category = Category.createCategory("testCategory", null);
+            categoryRepository.save(category);
         }
 
         @Test
@@ -79,20 +63,9 @@ class ClothServiceTest extends IntegrationTest {
             ClothCreateRequests request =
                     new ClothCreateRequests(
                             List.of(
+                                    new ClothCreateRequest("testClothImageUrl1", 1L, Season.SPRING),
                                     new ClothCreateRequest(
-                                            "testClothImageUrl1",
-                                            "testClothUrl1",
-                                            "testName1",
-                                            "testBrand1",
-                                            Season.SPRING,
-                                            2L),
-                                    new ClothCreateRequest(
-                                            "testClothImageUrl2",
-                                            "testClothUrl2",
-                                            "testName2",
-                                            "testBrand2",
-                                            Season.SUMMER,
-                                            2L)));
+                                            "testClothImageUrl2", 1L, Season.SPRING)));
 
             // when
             clothService.createClothes(request);
@@ -101,40 +74,12 @@ class ClothServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () ->
                             assertThat(clothRepository.findById(1L).orElseThrow())
-                                    .extracting(
-                                            "clothImageUrl",
-                                            "clothUrl",
-                                            "name",
-                                            "brand",
-                                            "season",
-                                            "category.id",
-                                            "member.id")
-                                    .containsExactly(
-                                            "testClothImageUrl1",
-                                            "testClothUrl1",
-                                            "testName1",
-                                            "testBrand1",
-                                            Season.SPRING,
-                                            2L,
-                                            1L),
+                                    .extracting("clothImageUrl", "category.id", "member.id")
+                                    .containsExactly("testClothImageUrl1", 1L, 1L),
                     () ->
                             assertThat(clothRepository.findById(2L).orElseThrow())
-                                    .extracting(
-                                            "clothImageUrl",
-                                            "clothUrl",
-                                            "name",
-                                            "brand",
-                                            "season",
-                                            "category.id",
-                                            "member.id")
-                                    .containsExactly(
-                                            "testClothImageUrl2",
-                                            "testClothUrl2",
-                                            "testName2",
-                                            "testBrand2",
-                                            Season.SUMMER,
-                                            2L,
-                                            1L));
+                                    .extracting("clothImageUrl", "category.id", "member.id")
+                                    .containsExactly("testClothImageUrl2", 1L, 1L));
         }
 
         @Test
@@ -143,52 +88,14 @@ class ClothServiceTest extends IntegrationTest {
             ClothCreateRequests request =
                     new ClothCreateRequests(
                             List.of(
+                                    new ClothCreateRequest("testClothImageUrl1", 1L, Season.SPRING),
                                     new ClothCreateRequest(
-                                            "testClothImageUrl1",
-                                            "testClothUrl1",
-                                            "testName1",
-                                            "testBrand1",
-                                            Season.SPRING,
-                                            2L),
-                                    new ClothCreateRequest(
-                                            "testClothImageUrl2",
-                                            "testClothUrl2",
-                                            "testName2",
-                                            "testBrand2",
-                                            Season.SPRING,
-                                            999L)));
+                                            "testClothImageUrl2", 999L, Season.SPRING)));
 
             // when & then
             assertThatThrownBy(() -> clothService.createClothes(request))
                     .isInstanceOf(BaseCustomException.class)
                     .hasMessage(CategoryErrorCode.CATEGORY_IN_BULK_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        void 상위_카테고리로_옷을_분류하는_경우_예외가_발생한다() {
-            // given
-            ClothCreateRequests request =
-                    new ClothCreateRequests(
-                            List.of(
-                                    new ClothCreateRequest(
-                                            "testClothImageUrl1",
-                                            "testClothUrl1",
-                                            "testName1",
-                                            "testBrand1",
-                                            Season.SPRING,
-                                            2L),
-                                    new ClothCreateRequest(
-                                            "testClothImageUrl2",
-                                            "testClothUrl2",
-                                            "testName2",
-                                            "testBrand2",
-                                            Season.SPRING,
-                                            1L)));
-
-            // when & then
-            assertThatThrownBy(() -> clothService.createClothes(request))
-                    .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(ClothErrorCode.PARENT_CATEGORY_CLOTH.getMessage());
         }
     }
 
@@ -210,24 +117,12 @@ class ClothServiceTest extends IntegrationTest {
             Category category2 = Category.createCategory("testCategory2", null);
             categoryRepository.saveAll(List.of(category1, category2));
 
-            Cloth cloth1 =
-                    Cloth.createCloth(
-                            "testImageUrl1", null, null, null, Season.SUMMER, category1, member);
-            Cloth cloth2 =
-                    Cloth.createCloth(
-                            "testImageUrl2", null, null, null, Season.SPRING, category1, member);
-            Cloth cloth3 =
-                    Cloth.createCloth(
-                            "testImageUrl3", null, null, null, Season.SPRING, category1, member);
-            Cloth cloth4 =
-                    Cloth.createCloth(
-                            "testImageUrl4", null, null, null, Season.SUMMER, category1, member);
-            Cloth cloth5 =
-                    Cloth.createCloth(
-                            "testImageUrl5", null, null, null, Season.WINTER, category1, member);
-            Cloth cloth6 =
-                    Cloth.createCloth(
-                            "testImageUrl6", null, null, null, Season.FALL, category1, member);
+            Cloth cloth1 = Cloth.createCloth("testImageUrl1", category1, Season.SUMMER, member);
+            Cloth cloth2 = Cloth.createCloth("testImageUrl2", category1, Season.SPRING, member);
+            Cloth cloth3 = Cloth.createCloth("testImageUrl3", category1, Season.SPRING, member);
+            Cloth cloth4 = Cloth.createCloth("testImageUrl4", category1, Season.SUMMER, member);
+            Cloth cloth5 = Cloth.createCloth("testImageUrl5", category1, Season.WINTER, member);
+            Cloth cloth6 = Cloth.createCloth("testImageUrl6", category1, Season.FALL, member);
 
             clothRepository.saveAll(List.of(cloth1, cloth2, cloth3, cloth4, cloth5, cloth6));
         }
@@ -254,427 +149,8 @@ class ClothServiceTest extends IntegrationTest {
             assertThat(response.content()).extracting("clothId").containsExactly(1L, 4L, 5L, 6L);
         }
 
-        @Test
-        void 옷을_모두_조회한_경우_빈_리스트를_반환한다() {
-            // when
-            SliceResponse<ClothRecommendListResponse> response =
-                    clothService.recommendCategoryClothes(6L, 4, 1L, Season.SPRING);
-
-            // then
-            assertThat(response.content()).isEmpty();
-        }
-
-        @Test
-        void 카테고리_옷이_존재하지_않는_경우_빈_리스트를_반환한다() {
-            // when
-            SliceResponse<ClothRecommendListResponse> response =
-                    clothService.recommendCategoryClothes(null, 4, 2L, Season.SPRING);
-
-            // then
-            assertThat(response.content()).isEmpty();
-        }
-
-        @Test
-        void 마지막_페이지인_경우_isLast를_true로_반환한다() {
-            // when
-            SliceResponse<ClothRecommendListResponse> response =
-                    clothService.recommendCategoryClothes(null, 6, 1L, Season.SPRING);
-
-            // then
-            assertThat(response.isLast()).isTrue();
-        }
-
-        @Test
-        void 마지막_페이지가_아닌_경우_isLast를_false로_반환한다() {
-            // when
-            SliceResponse<ClothRecommendListResponse> response =
-                    clothService.recommendCategoryClothes(null, 5, 1L, Season.SPRING);
-
-            // then
-            assertThat(response.isLast()).isFalse();
-        }
-    }
-
-    @Nested
-    class 옷_목록을_조회할_때 {
-
-        @BeforeEach
-        void setUp() {
-            Member member =
-                    Member.createMember(
-                            "testEmail1",
-                            "testClokeyId1",
-                            "testNickName1",
-                            OauthInfo.createOauthInfo("testOauthId1", OauthProvider.KAKAO));
-            memberRepository.save(member);
-            given(memberUtil.getCurrentMember()).willReturn(member);
-
-            Category category1 = Category.createCategory("testCategory1", null);
-            Category category2 = Category.createCategory("testCategory2", category1);
-            Category category3 = Category.createCategory("testCategory3", category1);
-            categoryRepository.saveAll(List.of(category1, category2, category3));
-
-            Cloth cloth1 =
-                    Cloth.createCloth(
-                            "testImageUrl1", null, null, null, Season.SPRING, category2, member);
-            Cloth cloth2 =
-                    Cloth.createCloth(
-                            "testImageUrl2", null, null, null, Season.SPRING, category2, member);
-            Cloth cloth3 =
-                    Cloth.createCloth(
-                            "testImageUrl3", null, null, null, Season.SUMMER, category2, member);
-            Cloth cloth4 =
-                    Cloth.createCloth(
-                            "testImageUrl4", null, null, null, Season.SPRING, category3, member);
-            Cloth cloth5 =
-                    Cloth.createCloth(
-                            "testImageUrl5", null, null, null, Season.SUMMER, category3, member);
-            Cloth cloth6 =
-                    Cloth.createCloth(
-                            "testImageUrl6", null, null, null, Season.FALL, category3, member);
-            clothRepository.saveAll(List.of(cloth1, cloth2, cloth3, cloth4, cloth5, cloth6));
-        }
-
-        @ParameterizedTest(name = "기본_조건_정렬_테스트 – direction={0}")
-        @MethodSource("sortDirectionCases")
-        void 기본_조건_정렬_테스트(SortDirection direction, List<Long> expected) {
-            // when
-            SliceResponse<ClothListResponse> response =
-                    clothService.getClothes(null, 6, direction, null, null);
-
-            // then
-            assertThat(response.content())
-                    .extracting("clothId")
-                    .containsExactlyElementsOf(expected);
-        }
-
-        private static Stream<Arguments> sortDirectionCases() {
-            return Stream.of(
-                    Arguments.of(SortDirection.ASC, List.of(1L, 2L, 3L, 4L, 5L, 6L)),
-                    Arguments.of(SortDirection.DESC, List.of(6L, 5L, 4L, 3L, 2L, 1L)));
-        }
-
-        @ParameterizedTest(name = "기본_조건_isLast_테스트 – size={0}")
-        @CsvSource({"5, false", "6, true"})
-        void 기본_조건_isLast_테스트(int size, boolean expectedIsLast) {
-            // when
-            SliceResponse<ClothListResponse> response =
-                    clothService.getClothes(null, size, SortDirection.ASC, null, null);
-
-            // then
-            assertThat(response.isLast()).isEqualTo(expectedIsLast);
-        }
-
-        @Test
-        void lastClothId를_입력하면_다음_cloth_부터_조회한다() {
-            // when
-            SliceResponse<ClothListResponse> response =
-                    clothService.getClothes(2L, 4, SortDirection.ASC, null, null);
-
-            // then
-            assertThat(response.content()).extracting("clothId").containsExactly(3L, 4L, 5L, 6L);
-        }
-
-        @Test
-        void 상위_카테고리_ID를_입력한_경우_하위_카테고리_옷들을_모두_조회한다() {
-            // when
-            SliceResponse<ClothListResponse> response =
-                    clothService.getClothes(null, 6, SortDirection.ASC, 1L, null);
-
-            // then
-            assertThat(response.content())
-                    .extracting("clothId")
-                    .containsExactly(1L, 2L, 3L, 4L, 5L, 6L);
-        }
-
-        @Test
-        void 하위_카테고리_ID를_입력한_해당_카테고리_옷들을_모두_조회한다() {
-            // when
-            SliceResponse<ClothListResponse> response =
-                    clothService.getClothes(null, 3, SortDirection.ASC, 2L, null);
-
-            // then
-            assertThat(response.content()).extracting("clothId").containsExactly(1L, 2L, 3L);
-        }
-
-        @ParameterizedTest(name = "계절_필터_테스트 – seasons={0}")
-        @MethodSource("seasonFilterCases")
-        void 계절을_넣는_경우_해당_계절의_옷을_모두_조회한다(List<Season> seasons, List<Long> expected) {
-            // when
-            SliceResponse<ClothListResponse> response =
-                    clothService.getClothes(null, 10, SortDirection.ASC, null, seasons);
-
-            // then
-            assertThat(response.content())
-                    .extracting("clothId")
-                    .containsExactlyElementsOf(expected);
-        }
-
-        private static Stream<Arguments> seasonFilterCases() {
-            return Stream.of(
-                    Arguments.of(List.of(Season.SPRING), List.of(1L, 2L, 4L)),
-                    Arguments.of(List.of(Season.SUMMER), List.of(3L, 5L)),
-                    Arguments.of(List.of(Season.FALL), List.of(6L)),
-                    Arguments.of(
-                            List.of(Season.SPRING, Season.SUMMER), List.of(1L, 2L, 3L, 4L, 5L)));
-        }
-
-        @Test
-        void 복합_조건_테스트() {
-            // when
-            SliceResponse<ClothListResponse> response =
-                    clothService.getClothes(2L, 4, SortDirection.ASC, 3L, List.of(Season.SPRING));
-
-            // then
-            assertThat(response.content()).extracting("clothId").containsExactly(4L);
-        }
-
-        @Test
-        void 카테고리가_존재하지_않는_경우_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(
-                            () -> clothService.getClothes(null, 6, SortDirection.ASC, 999L, null))
-                    .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(CategoryErrorCode.CATEGORY_NOT_FOUND.getMessage());
-        }
-    }
-
-    @Nested
-    class 옷을_상세_조회할_때 {
-
-        @BeforeEach
-        void setUp() {
-            Member member1 =
-                    Member.createMember(
-                            "testEmail1",
-                            "testClokeyId1",
-                            "testNickName1",
-                            OauthInfo.createOauthInfo("testOauthId1", OauthProvider.KAKAO));
-            Member member2 =
-                    Member.createMember(
-                            "testEmail2",
-                            "testClokeyId2",
-                            "testNickName2",
-                            OauthInfo.createOauthInfo("testOauthId2", OauthProvider.KAKAO));
-            memberRepository.saveAll(List.of(member1, member2));
-            given(memberUtil.getCurrentMember()).willReturn(member1);
-
-            Category parentCategory = Category.createCategory("testParentCategory", null);
-            Category category = Category.createCategory("testCategory", parentCategory);
-            categoryRepository.saveAll(List.of(parentCategory, category));
-
-            Cloth cloth1 =
-                    Cloth.createCloth(
-                            "testImageUrl1", null, null, null, Season.SPRING, category, member1);
-            Cloth cloth2 =
-                    Cloth.createCloth(
-                            "testImageUrl2", null, null, null, Season.SPRING, category, member2);
-            clothRepository.saveAll(List.of(cloth1, cloth2));
-        }
-
-        @Test
-        void 유효한_요청이면_옷_상세_정보를_반환한다() {
-            // when
-            ClothDetailsResponse response = clothService.getClothDetails(1L);
-
-            // then
-            assertThat(response)
-                    .extracting(
-                            "clothImageUrl",
-                            "parentCategory",
-                            "category",
-                            "name",
-                            "brand",
-                            "clothUrl")
-                    .containsExactly(
-                            "testImageUrl1",
-                            "testParentCategory",
-                            "testCategory",
-                            null,
-                            null,
-                            null);
-        }
-
-        @Test
-        void 존재하지_않는_categoryId를_입력하면_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(() -> clothService.getClothDetails(999L))
-                    .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(ClothErrorCode.ClOTH_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        void 옷의_소유자가_아닌_경우_예외가_발생한다() {
-            // when & then
-            assertThatThrownBy(() -> clothService.getClothDetails(2L))
-                    .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(ClothErrorCode.NOT_CLOTH_OWNER.getMessage());
-        }
-    }
-
-    @Nested
-    class 옷을_수정할_때 {
-
-        @BeforeEach
-        void setUp() {
-            Member member1 =
-                    Member.createMember(
-                            "testEmail1",
-                            "testClokeyId1",
-                            "testNickName1",
-                            OauthInfo.createOauthInfo("testOauthId1", OauthProvider.KAKAO));
-            Member member2 =
-                    Member.createMember(
-                            "testEmail2",
-                            "testClokeyId2",
-                            "testNickName2",
-                            OauthInfo.createOauthInfo("testOauthId2", OauthProvider.KAKAO));
-            memberRepository.saveAll(List.of(member1, member2));
-            given(memberUtil.getCurrentMember()).willReturn(member1);
-
-            Category parentCategory = Category.createCategory("testParentCategory", null);
-            Category category = Category.createCategory("testCategory", parentCategory);
-            categoryRepository.saveAll(List.of(parentCategory, category));
-
-            Cloth cloth1 =
-                    Cloth.createCloth(
-                            "testImageUrl1",
-                            "testClothUrl",
-                            "testName",
-                            "testBrand",
-                            Season.SPRING,
-                            category,
-                            member1);
-            Cloth cloth2 =
-                    Cloth.createCloth(
-                            "testImageUrl2", null, null, null, Season.SPRING, category, member2);
-            clothRepository.saveAll(List.of(cloth1, cloth2));
-        }
-
-        @Test
-        void 유효한_요청이면_옷을_수정한다() {
-            // given
-            ClothUpdateRequest request =
-                    new ClothUpdateRequest(
-                            "newClothImageUrl",
-                            "newClothUrl",
-                            "newName",
-                            "newBrand",
-                            Season.SUMMER,
-                            2L);
-
-            // when
-            clothService.updateCloth(1L, request);
-
-            assertThat(clothRepository.findById(1L).orElseThrow())
-                    .extracting(
-                            "clothImageUrl",
-                            "clothUrl",
-                            "name",
-                            "brand",
-                            "season",
-                            "category.id",
-                            "member.id")
-                    .containsExactly(
-                            "newClothImageUrl",
-                            "newClothUrl",
-                            "newName",
-                            "newBrand",
-                            Season.SUMMER,
-                            2L,
-                            1L);
-        }
-
-        @Test
-        void 옷의_이미지_url이_수정되는_경우_기존_url을_삭제하는_이벤트를_발행한다() {
-            // given
-            ClothUpdateRequest request =
-                    new ClothUpdateRequest(
-                            "newClothImageUrl",
-                            "newClothUrl",
-                            "newName",
-                            "newBrand",
-                            Season.SUMMER,
-                            2L);
-
-            // when
-            clothService.updateCloth(1L, request);
-
-            var events = applicationEvents.stream(ImageDeleteEvent.class).toList();
-            assertThat(events).hasSize(1);
-            assertThat(events.getFirst().imageUrl()).isEqualTo("testImageUrl1");
-        }
-
-        @Test
-        void 옷이_존재하지_않으면_예외가_발생한다() {
-            // given
-            ClothUpdateRequest request =
-                    new ClothUpdateRequest(
-                            "newClothImageUrl",
-                            "newClothUrl",
-                            "newName",
-                            "newBrand",
-                            Season.SUMMER,
-                            2L);
-
-            // when & then
-            assertThatThrownBy(() -> clothService.updateCloth(999L, request))
-                    .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(ClothErrorCode.ClOTH_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        void 카테고리가_존재하지_않으면_예외가_발생한다() {
-            // given
-            ClothUpdateRequest request =
-                    new ClothUpdateRequest(
-                            "newClothImageUrl",
-                            "newClothUrl",
-                            "newName",
-                            "newBrand",
-                            Season.SUMMER,
-                            999L);
-
-            // when & then
-            assertThatThrownBy(() -> clothService.updateCloth(1L, request))
-                    .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(CategoryErrorCode.CATEGORY_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        void 나의_옷이_아닌_경우_예외가_발생한다() {
-            // given
-            ClothUpdateRequest request =
-                    new ClothUpdateRequest(
-                            "newClothImageUrl",
-                            "newClothUrl",
-                            "newName",
-                            "newBrand",
-                            Season.SUMMER,
-                            2L);
-
-            // when & then
-            assertThatThrownBy(() -> clothService.updateCloth(2L, request))
-                    .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(ClothErrorCode.NOT_CLOTH_OWNER.getMessage());
-        }
-
-        @Test
-        void 부모_카테고리를_옷에_등록하려는_경우_예외가_발생한다() {
-            // given
-            ClothUpdateRequest request =
-                    new ClothUpdateRequest(
-                            "newClothImageUrl",
-                            "newClothUrl",
-                            "newName",
-                            "newBrand",
-                            Season.SUMMER,
-                            1L);
-
-            // when & then
-            assertThatThrownBy(() -> clothService.updateCloth(1L, request))
-                    .isInstanceOf(BaseCustomException.class)
-                    .hasMessage(ClothErrorCode.PARENT_CATEGORY_CLOTH.getMessage());
-        }
+        // lastId
+        // 빈 리스트
+        // isLast조건!
     }
 }

--- a/clokey-infrastructure/src/main/java/org/clokey/util/S3Util.java
+++ b/clokey-infrastructure/src/main/java/org/clokey/util/S3Util.java
@@ -25,9 +25,9 @@ public class S3Util {
     private final S3Properties s3Properties;
 
     public String createPresignedUrl(
-            ImageType imageType, Long targetId, FileExtension fileExtension, String md5Hash) {
+            ImageType imageType, Long memberId, FileExtension fileExtension, String md5Hash) {
         String imageKey = UUID.randomUUID().toString();
-        String fileName = createFileName(imageType, targetId, imageKey, fileExtension);
+        String fileName = createFileName(imageType, memberId, imageKey, fileExtension);
         String bucket = s3Properties.bucket();
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest =


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #106 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- presignedUrl 발급 로직 수정 & 검증 로직 추가

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->

아주 아주 중요한 부분입니다.

s3의 이미지 삭제는 크게 어려운 것이 없기 때문에 업로드 라이프사이클에 대해서 설명하겠습니다.
저 만의 PresignedUrl을 올바르게 사용하기 위한 방법이며, 더 좋은 의견이 있다면 남겨주셔도 좋습니다.

PresignedUrl을 사용하는 이유는 이미지 업로드에서 성능을 보장하기 위함입니다.
다만, 부수적으로 번거로운 부분들이 생기며 그 부분을 최대한 ~ 없애기 위해 노력했습니다.

이미지 업로드, 그리고 검증 API 개발시 아래 내용을 참고하시면 됩니다.

1. 먼저, 이미지 업로드가 필요한 부분에서 s3 util의 createPresignedUrl을 사용하시면 됩니다. (업로드 요청 API 만들어야 함)
ex) 옷 생성 API에서 imageUrl을 입력값으로 받으니 "옷 이미지 업로드 API"를 만들어 주시면 됩니다. (이미지 업로드 API를 하나만 만들어 통일하지는 않겠습니다. 각 Task마다 필요한 검증이 다르기에 (옷은 누구 소유인지.. 프로필 업로드는 또 저런거 필요없으니)

⭐ presignedUrl의 경로에 userId가 들어가게 되는데요.. (증말 증말 중요하다)

의도는 다음과 같습니다. 유저가 탈퇴하는 경우 관련된 엔티티를 모두 삭제하고 s3사진또한 삭제해 주어야 하는데요.
이 부분에서 userId 기반으로 s3에 있는 것들을 모두 삭제하기 위함입니다. (s3는 경로 기반 모두 삭제가 가능합니다.)

history  같은 경우도 이와 같은 방식을 사용하면 좋으나~!!!!!
⭐ PresignedUrl은 근본적으로 엔티티가 생성되기 전에 이미지를 업로드 해야합니다.

이에 따라서, 이미지 보다 엔티티가 먼저 생성되는 과정은 많이 없어서 유저 ID만 반영했습니다. 
만약 history를 먼저 생성하고 이미지를 만든다? 이러면 그런 부분들에도 presignedUrl 발급에 반영하면 좋겠죠..? (삭제할 때 편합니다...) but 없다는 점 알아두시면 됩니다. 

✅  아무튼 다시 돌아와서,

PresignedUrl을 발급을 하는 과정에서 MD5해시를 요구하고 있습니다.
이는 이미지 업로드 시점에 **파일이 변형되지 않고 올라갔는지!?** 확인을 하기 위한 수단입니다. -> 업로드를 클라이언트에게 위임했으니 무결성에 대한 최소한 부분을 해시값으로 검증합니다. (만약 클라이언트가 사진을 업로드했는데 presignedUrl 발급시의 해시와 다르다면 업로드 실패함)

참고로, 제 코드가 AWS sdk v1을 사용하기 때문에 MD5해시를 사용했구요. v2를 쓰면 더 좋은 해시들도 있는데 굳이 사용하지 않는 이유는 따로 없습니다. 제가 현재는 시간이 없어서 그 부분은 추후에 디벨롭 할 수 있는 과제로 남겨두겠습니다.

⭐⭐⭐ 2. 다음으로 업로드 검증 API를 만들면 됨다.
업로드 후에 클라이언트는 업로드 검증 API를 사용하게 됩니다.

이걸 호출하면 백에서는 클라이언트가 입력한 주소 http://example.jpg를 찔러보고 그 곳에 사진이 업로드 되어 있는 것을 확인하면 엔티티로 만들어줍니다. (ex: historyImage) 이때 S3 util의 **doesFileExistByUrl**를 사용해 주세요.

- 업로드 유무만 확인하는 이유는 MD5 해시로 무결성은 보장이 된다고 가정하기 때문.
- 또한 이 과정에서 status = pending -> status = complete로 수정하는 방법으로 별도의 cleaner를 was 진영에서 만들지 않습니다. (행복하죠?)

⭐⭐⭐ 대신!!! s3 버킷 내부에 status 태그가 pending인 이미지들은 하루에 한번씩 지워주는 부분을 추가해야합니다. @2ghrms 이 부분을 terraform과 함께 작업해 주셔야 합니다. (어렵진 않으니 gpt를 사용해보심이... 복붙만 하면 됩니다 aws에서 규칙만 추가하면 됨다.)

따라서, 어떠한 이유든 에러든 프론트가 검증 API 호출을 통해서 status 태그를 수정하지 못한 이미지들은 s3가 알아서 관리를 해주게 됩니다.