### PR TITLE
[feat/#106] tag 추가 및 update 로직 구현

### DIFF
--- a/clokey-infrastructure/src/main/java/org/clokey/util/S3Util.java
+++ b/clokey-infrastructure/src/main/java/org/clokey/util/S3Util.java
@@ -1,11 +1,10 @@
 package org.clokey.util;
 
 import com.amazonaws.HttpMethod;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.*;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -26,9 +25,9 @@ public class S3Util {
     private final S3Properties s3Properties;
 
     public String createPresignedUrl(
-            ImageType imageType, Long targetId, FileExtension fileExtension, String md5Hash) {
+            ImageType imageType, Long memberId, FileExtension fileExtension, String md5Hash) {
         String imageKey = UUID.randomUUID().toString();
-        String fileName = createFileName(imageType, targetId, imageKey, fileExtension);
+        String fileName = createFileName(imageType, memberId, imageKey, fileExtension);
         String bucket = s3Properties.bucket();
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
@@ -59,6 +58,8 @@ public class S3Util {
 
         generatePresignedUrlRequest.addRequestParameter(
                 Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        generatePresignedUrlRequest.addRequestParameter("x-amz-tagging", "status=pending");
 
         generatePresignedUrlRequest.setContentMd5(md5Hash);
 
@@ -100,5 +101,51 @@ public class S3Util {
         expiration.setTime(expTimeMillis);
 
         return expiration;
+    }
+
+    public void updateTagToCompleteByUrl(String url) {
+        String bucket = s3Properties.bucket();
+        String key = extractObjectKey(url);
+
+        List<Tag> tags = List.of(new Tag("status", "complete"));
+        ObjectTagging tagging = new ObjectTagging(tags);
+
+        SetObjectTaggingRequest request = new SetObjectTaggingRequest(bucket, key, tagging);
+        amazonS3.setObjectTagging(request);
+    }
+
+    public void updateTagsToCompleteByUrls(List<String> urls) {
+        for (String url : urls) {
+            updateTagToCompleteByUrl(url);
+        }
+    }
+
+    public boolean doesFileExistByUrl(String url) {
+        String bucket = s3Properties.bucket();
+        String key = extractObjectKey(url);
+        try {
+            return amazonS3.doesObjectExist(bucket, key);
+        } catch (AmazonS3Exception e) {
+            if (e.getStatusCode() == 403) {
+                log.warn("Access denied for key={}, treating as non-existent", key);
+                return false;
+            }
+            log.error("S3 error while checking existence: {}", e.getErrorMessage(), e);
+            return false;
+        } catch (SdkClientException e) {
+            log.error("Network error while connecting to S3: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean doAllFilesExistByUrls(List<String> urls) {
+        for (String url : urls) {
+            if (!doesFileExistByUrl(url)) {
+                log.warn("File not found or inaccessible: {}", url);
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #106 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->

## 🛠 작업 내용
아주 아주 중요한 부분입니다.

s3의 이미지 삭제는 크게 어려운 것이 없기 때문에 업로드 라이프사이클에 대해서 설명하겠습니다.
저 만의 PresignedUrl을 올바르게 사용하기 위한 방법이며, 더 좋은 의견이 있다면 남겨주셔도 좋습니다.

PresignedUrl을 사용하는 이유는 이미지 업로드에서 성능을 보장하기 위함입니다.
다만, 부수적으로 번거로운 부분들이 생기며 그 부분을 최대한 ~ 없애기 위해 노력했습니다.

이미지 업로드, 그리고 검증 API 개발시 아래 내용을 참고하시면 됩니다.

먼저, 이미지 업로드가 필요한 부분에서 s3 util의 createPresignedUrl을 사용하시면 됩니다. (업로드 요청 API 만들어야 함)
ex) 옷 생성 API에서 imageUrl을 입력값으로 받으니 "옷 이미지 업로드 API"를 만들어 주시면 됩니다. (이미지 업로드 API를 하나만 만들어 통일하지는 않겠습니다. 각 Task마다 필요한 검증이 다르기에 (옷은 누구 소유인지.. 프로필 업로드는 또 저런거 필요없으니)
⭐ presignedUrl의 경로에 userId가 들어가게 되는데요.. (증말 증말 중요하다)

의도는 다음과 같습니다. 유저가 탈퇴하는 경우 관련된 엔티티를 모두 삭제하고 s3사진또한 삭제해 주어야 하는데요.
이 부분에서 userId 기반으로 s3에 있는 것들을 모두 삭제하기 위함입니다. (s3는 경로 기반 모두 삭제가 가능합니다.)

history 같은 경우도 이와 같은 방식을 사용하면 좋으나~!!!!!
⭐ PresignedUrl은 근본적으로 엔티티가 생성되기 전에 이미지를 업로드 해야합니다.

이에 따라서, 이미지 보다 엔티티가 먼저 생성되는 과정은 많이 없어서 유저 ID만 반영했습니다.
만약 history를 먼저 생성하고 이미지를 만든다? 이러면 그런 부분들에도 presignedUrl 발급에 반영하면 좋겠죠..? (삭제할 때 편합니다...) but 없다는 점 알아두시면 됩니다.

✅ 아무튼 다시 돌아와서,

PresignedUrl을 발급을 하는 과정에서 MD5해시를 요구하고 있습니다.
이는 이미지 업로드 시점에 파일이 변형되지 않고 올라갔는지!? 확인을 하기 위한 수단입니다. -> 업로드를 클라이언트에게 위임했으니 무결성에 대한 최소한 부분을 해시값으로 검증합니다. (만약 클라이언트가 사진을 업로드했는데 presignedUrl 발급시의 해시와 다르다면 업로드 실패함)

참고로, 제 코드가 AWS sdk v1을 사용하기 때문에 MD5해시를 사용했구요. v2를 쓰면 더 좋은 해시들도 있는데 굳이 사용하지 않는 이유는 따로 없습니다. 제가 현재는 시간이 없어서 그 부분은 추후에 디벨롭 할 수 있는 과제로 남겨두겠습니다.

⭐⭐⭐ 2. 다음으로 업로드 검증 API를 만들면 됨다.
업로드 후에 클라이언트는 업로드 검증 API를 사용하게 됩니다.

이걸 호출하면 백에서는 클라이언트가 입력한 주소 [http://example.jpg를](http://example.xn--jpg-hw8m/) 찔러보고 그 곳에 사진이 업로드 되어 있는 것을 확인하면 엔티티로 만들어줍니다. (ex: historyImage) 이때 S3 util의 doesFileExistByUrl를 사용해 주세요.

업로드 유무만 확인하는 이유는 MD5 해시로 무결성은 보장이 된다고 가정하기 때문.
또한 이 과정에서 status = pending -> status = complete로 수정하는 방법으로 별도의 cleaner를 was 진영에서 만들지 않습니다. (행복하죠?)
⭐⭐⭐ 대신!!! s3 버킷 내부에 status 태그가 pending인 이미지들은 하루에 한번씩 지워주는 부분을 추가해야합니다. @2ghrms 이 부분을 terraform과 함께 작업해 주셔야 합니다. (어렵진 않으니 gpt를 사용해보심이... 복붙만 하면 됩니다 aws에서 규칙만 추가하면 됨다.)

따라서, 어떠한 이유든 에러든 프론트가 검증 API 호출을 통해서 status 태그를 수정하지 못한 이미지들은 s3가 알아서 관리를 해주게 됩니다.