### PR TITLE
[fix/#167] api 필터에서 swagger 허용

### DIFF
--- a/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
+++ b/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
@@ -95,7 +95,8 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(
                         auth ->
-                                auth.requestMatchers("/public/**", "/swagger-ui/**", "/v3/api-docs/**")
+                                auth.requestMatchers(
+                                                "/public/**", "/swagger-ui/**", "/v3/api-docs/**")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #167 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
api 필터에서 swagger 허용

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- prod 프로필에서도 swagger 사용 가능하도록 필터에서 permit 해줌
- 실제 도메인 명으로 cors 허용
