### PR TITLE
[fix/#256] 일별 기록 조회에서 해시태그와 본문 반환

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/history/dto/response/DailyHistoryResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/history/dto/response/DailyHistoryResponse.java
@@ -15,7 +15,9 @@ public record DailyHistoryResponse(
         @Schema(description = "기록 날짜", example = "2025-01-01") LocalDate historyDate,
         @Schema(description = "상황 ID", example = "1") Long situationId,
         @Schema(description = "상황 이름", example = "데일리") String situationName,
-        @Schema(description = "스타일 목록") List<DailyHistoryResponse.StylePayload> styles) {
+        @Schema(description = "본문 내용", example = "오늘 날씨가 좋아서 산책을 다녀왔어요") String content,
+        @Schema(description = "스타일 목록") List<DailyHistoryResponse.StylePayload> styles,
+        @Schema(description = "해시태그 목록", example = "[\"데일리룩\", \"오늘의코디\"]") List<String> hashtags) {
 
     public static DailyHistoryResponse of(
             Long memberId,
@@ -27,7 +29,9 @@ public record DailyHistoryResponse(
             LocalDate historyDate,
             Long situationId,
             String situationName,
-            List<StylePayload> styles) {
+            String content,
+            List<StylePayload> styles,
+            List<String> hashtags) {
         return new DailyHistoryResponse(
                 memberId,
                 profileImageUrl,
@@ -38,7 +42,9 @@ public record DailyHistoryResponse(
                 historyDate,
                 situationId,
                 situationName,
-                styles);
+                content,
+                styles,
+                hashtags);
     }
 
     @Schema(name = "DailyHistoryResponseImagePayload", description = "기록 이미지 정보")

--- a/clokey-api/src/main/java/org/clokey/domain/history/service/HistoryServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/history/service/HistoryServiceImpl.java
@@ -245,6 +245,11 @@ public class HistoryServiceImpl implements HistoryService {
                                                 historyStyle.getStyle().getName()))
                         .toList();
 
+        List<String> hashtags =
+                historyHashtagRepository.findAllByHistoryIdWithHashtag(historyId).stream()
+                        .map(historyHashtag -> historyHashtag.getHashtag().getName())
+                        .toList();
+
         return DailyHistoryResponse.of(
                 history.getMember().getId(),
                 history.getMember().getProfileImageUrl(),
@@ -255,7 +260,9 @@ public class HistoryServiceImpl implements HistoryService {
                 history.getHistoryDate(),
                 history.getSituation().getId(),
                 history.getSituation().getName(),
-                styles);
+                history.getContent(),
+                styles,
+                hashtags);
     }
 
     @Override

--- a/clokey-api/src/test/java/org/clokey/domain/history/controller/HistoryControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/history/controller/HistoryControllerTest.java
@@ -729,9 +729,11 @@ public class HistoryControllerTest {
                             java.time.LocalDate.of(2025, 1, 1),
                             1L,
                             "testSituation",
+                            "testContent",
                             List.of(
                                     new DailyHistoryResponse.StylePayload(1L, "testStyle1"),
-                                    new DailyHistoryResponse.StylePayload(2L, "testStyle2")));
+                                    new DailyHistoryResponse.StylePayload(2L, "testStyle2")),
+                            List.of("testHashtag1", "testHashtag2"));
 
             given(historyService.getDailyHistory(1L)).willReturn(testDailyHistoryResponse);
 
@@ -755,10 +757,15 @@ public class HistoryControllerTest {
                     .andExpect(jsonPath("$.result.historyDate").value("2025-01-01"))
                     .andExpect(jsonPath("$.result.situationId").value(1L))
                     .andExpect(jsonPath("$.result.situationName").value("testSituation"))
+                    .andExpect(jsonPath("$.result.content").value("testContent"))
                     .andExpect(jsonPath("$.result.styles").isArray())
                     .andExpect(jsonPath("$.result.styles.length()").value(2))
                     .andExpect(jsonPath("$.result.styles[0].styleId").value(1L))
-                    .andExpect(jsonPath("$.result.styles[0].styleName").value("testStyle1"));
+                    .andExpect(jsonPath("$.result.styles[0].styleName").value("testStyle1"))
+                    .andExpect(jsonPath("$.result.hashtags").isArray())
+                    .andExpect(jsonPath("$.result.hashtags.length()").value(2))
+                    .andExpect(jsonPath("$.result.hashtags[0]").value("testHashtag1"))
+                    .andExpect(jsonPath("$.result.hashtags[1]").value("testHashtag2"));
         }
     }
 

--- a/clokey-api/src/test/java/org/clokey/domain/history/service/HistoryServiceImplTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/history/service/HistoryServiceImplTest.java
@@ -1014,6 +1014,10 @@ class HistoryServiceImplTest extends IntegrationTest {
             Style style2 = Style.createStyle("testStyle2");
             styleRepository.saveAll(List.of(style1, style2));
 
+            Hashtag hashtag1 = Hashtag.createHashtag("testhashtag1");
+            Hashtag hashtag2 = Hashtag.createHashtag("testhashtag2");
+            hashtagRepository.saveAll(List.of(hashtag1, hashtag2));
+
             History history1 =
                     History.createHistory(LocalDate.now(), "testContent1", member1, situation1);
             History history2 =
@@ -1031,6 +1035,11 @@ class HistoryServiceImplTest extends IntegrationTest {
                     List.of(
                             HistoryStyle.createHistoryStyle(history1, style1),
                             HistoryStyle.createHistoryStyle(history1, style2)));
+
+            historyHashtagRepository.bulkInsertHistoryHashtags(
+                    List.of(
+                            HistoryHashtag.createHistoryHashtag(history1, hashtag1),
+                            HistoryHashtag.createHistoryHashtag(history1, hashtag2)));
         }
 
         @Test
@@ -1045,9 +1054,11 @@ class HistoryServiceImplTest extends IntegrationTest {
                             DailyHistoryResponse::historyDate,
                             DailyHistoryResponse::situationId,
                             DailyHistoryResponse::situationName,
+                            DailyHistoryResponse::content,
                             DailyHistoryResponse::likeCount,
                             DailyHistoryResponse::commentCount)
-                    .containsExactly(1L, LocalDate.now(), 1L, "testSituation1", 0L, 0L);
+                    .containsExactly(
+                            1L, LocalDate.now(), 1L, "testSituation1", "testContent1", 0L, 0L);
 
             assertThat(response.images()).hasSize(2);
             assertThat(response.images())
@@ -1063,6 +1074,10 @@ class HistoryServiceImplTest extends IntegrationTest {
                             DailyHistoryResponse.StylePayload::styleId,
                             DailyHistoryResponse.StylePayload::styleName)
                     .containsExactlyInAnyOrder(tuple(1L, "testStyle1"), tuple(2L, "testStyle2"));
+
+            assertThat(response.hashtags()).hasSize(2);
+            assertThat(response.hashtags())
+                    .containsExactlyInAnyOrder("testhashtag1", "testhashtag2");
         }
 
         @Test


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #256

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 일별 기록 조회에서 해시태그와 본문 반환
