### PR TITLE
[refactor/#336] 피드 조회 API 응답 isMine 필드 추가

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/feed/dto/response/FeedListResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/feed/dto/response/FeedListResponse.java
@@ -21,6 +21,7 @@ public record FeedListResponse(
             @Schema(description = "대표 이미지 URL", example = "https://example.com/image.jpg")
                     String imageUrl,
             @Schema(description = "좋아요 여부", example = "true") boolean isLiked,
+            @Schema(description = "작성자 본인 여부", example = "false") boolean isMine,
             @Schema(description = "작성자 정보") FeedAuthorResponse author) {}
 
     @Schema(name = "FeedAuthorResponse", description = "피드 작성자 정보")

--- a/clokey-api/src/main/java/org/clokey/domain/feed/service/FeedServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/feed/service/FeedServiceImpl.java
@@ -143,6 +143,9 @@ public class FeedServiceImpl implements FeedService {
                                                 history.getCreatedAt(),
                                                 imageUrlMap.get(history.getId()),
                                                 likedHistoryIds.contains(history.getId()),
+                                                history.getMember()
+                                                        .getId()
+                                                        .equals(currentMember.getId()),
                                                 toAuthorResponse(
                                                         history.getMember(),
                                                         followedMemberIds.contains(

--- a/clokey-api/src/test/java/org/clokey/domain/feed/controller/FeedControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/feed/controller/FeedControllerTest.java
@@ -42,6 +42,7 @@ public class FeedControllerTest {
                                             LocalDateTime.parse("2025-01-01T12:00:00"),
                                             "https://image.test/10.png",
                                             true,
+                                            false,
                                             new FeedListResponse.FeedAuthorResponse(
                                                     2L,
                                                     "clokey2",
@@ -76,6 +77,7 @@ public class FeedControllerTest {
                             jsonPath("$.result.items[0].imageUrl")
                                     .value("https://image.test/10.png"))
                     .andExpect(jsonPath("$.result.items[0].isLiked").value(true))
+                    .andExpect(jsonPath("$.result.items[0].isMine").value(false))
                     .andExpect(jsonPath("$.result.items[0].author.memberId").value(2L))
                     .andExpect(jsonPath("$.result.items[0].author.nickname").value("clokey2"))
                     .andExpect(


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #336 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
프론트 요청으로 인한 피드 조회 API 응답 isMine 필드 추가

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 피드 리스트의 기록이 현재 유저의 기록인지 나타내는 isMine 필드 추가
- response, service, controllerTest 관련 부분 수정

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
