### PR TITLE
[fix/#378] Apple login 오류 해결

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/auth/service/CustomOAuth2UserService.java
+++ b/clokey-api/src/main/java/org/clokey/domain/auth/service/CustomOAuth2UserService.java
@@ -18,6 +18,7 @@ import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
@@ -57,6 +58,7 @@ public class CustomOAuth2UserService extends OidcUserService {
 
             OauthProvider oauthProvider = OauthProvider.valueOf(provider.toUpperCase());
             OauthInfo oauthInfo = OauthInfo.createOauthInfo(oauthId, oauthProvider);
+            String resolvedEmail = resolveEmail(email, oauthId, oauthProvider);
 
             log.info("[OIDC] 회원 조회 시작 - Provider: {}, OAuthId: {}", provider, oauthId);
             Member member =
@@ -70,7 +72,7 @@ public class CustomOAuth2UserService extends OidcUserService {
                                                 email);
                                         Member newMember =
                                                 Member.createMember(
-                                                        email,
+                                                        resolvedEmail,
                                                         uniqueUtil.generateRandomNickname(),
                                                         oauthInfo);
                                         memberRepository.save(newMember);
@@ -111,5 +113,24 @@ public class CustomOAuth2UserService extends OidcUserService {
                             null);
             throw new OAuth2AuthenticationException(oauth2Error, e);
         }
+    }
+
+    private String resolveEmail(String email, String oauthId, OauthProvider oauthProvider) {
+        if (StringUtils.hasText(email)) {
+            return email;
+        }
+
+        String safeOauthId = oauthId.replaceAll("[^a-zA-Z0-9._-]", "_");
+        if (safeOauthId.length() > 80) {
+            safeOauthId = safeOauthId.substring(0, 80);
+        }
+        String fallbackEmail =
+                oauthProvider.name().toLowerCase() + "_" + safeOauthId + "@noemail.local";
+        log.warn(
+                "[OIDC] Email claim missing. Fallback email is used - Provider: {}, OAuthId: {}, FallbackEmail: {}",
+                oauthProvider,
+                oauthId,
+                fallbackEmail);
+        return fallbackEmail;
     }
 }

--- a/clokey-api/src/main/resources/application-dev.yml
+++ b/clokey-api/src/main/resources/application-dev.yml
@@ -57,6 +57,7 @@ spring:
             client-authentication-method: client_secret_post
             scope:
               - openid
+              - email
             provider: apple
         provider:
           kakao:

--- a/clokey-api/src/main/resources/application-local.yml
+++ b/clokey-api/src/main/resources/application-local.yml
@@ -57,6 +57,7 @@ spring:
             client-authentication-method: client_secret_post
             scope:
               - openid
+              - email
             provider: apple
         provider:
           kakao:

--- a/clokey-api/src/main/resources/application-prod.yml
+++ b/clokey-api/src/main/resources/application-prod.yml
@@ -57,6 +57,7 @@ spring:
             client-authentication-method: client_secret_post
             scope:
               - openid
+              - email
             provider: apple
         provider:
           kakao:


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #378 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
애플 로그인 invalid credentials 문제 해결

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 애플로그인 scope에 email 누락되어있어 추가하였습니다.
- 또한 email값을 null로 받을 때를 대비하는 로직을 추가하였습니다. (가입 실패 방지)
  - fallback 값은 provider + oauthId 기반이라 사실상 계정별로 고유합니다.                                                                                                                 

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
주의할 점은, 이후 기능에서 “실제 이메일”이 필요하면 @noemail.local 같은 fallback 주소를 구분해서 처리하면 됩니다. 