### PR TITLE
[fix/#381] Apple Login 정책 관련 누락 수정

### DIFF
--- a/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
+++ b/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.clokey.domain.auth.handler.OidcLoginSuccessHandler;
 import org.clokey.domain.auth.service.CustomOAuth2UserService;
 import org.clokey.domain.auth.service.JwtTokenService;
+import org.clokey.global.security.AppleAwareOAuth2AuthorizationRequestResolver;
 import org.clokey.global.security.JwtAuthenticationFilter;
 import org.clokey.helper.SpringEnvironmentHelper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +27,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestCustomizers;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
@@ -169,8 +169,8 @@ public class SecurityConfig {
         if (clientRegistrationRepository == null) {
             throw new IllegalStateException("ClientRegistrationRepository is required for OAuth2");
         }
-        DefaultOAuth2AuthorizationRequestResolver resolver =
-                new DefaultOAuth2AuthorizationRequestResolver(
+        AppleAwareOAuth2AuthorizationRequestResolver resolver =
+                new AppleAwareOAuth2AuthorizationRequestResolver(
                         clientRegistrationRepository, "/oauth2/authorization");
         resolver.setAuthorizationRequestCustomizer(
                 OAuth2AuthorizationRequestCustomizers.withPkce());

--- a/clokey-api/src/main/java/org/clokey/global/security/AppleAwareOAuth2AuthorizationRequestResolver.java
+++ b/clokey-api/src/main/java/org/clokey/global/security/AppleAwareOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,64 @@
+package org.clokey.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+@RequiredArgsConstructor
+public class AppleAwareOAuth2AuthorizationRequestResolver
+        implements OAuth2AuthorizationRequestResolver {
+
+    private final DefaultOAuth2AuthorizationRequestResolver delegate;
+
+    public AppleAwareOAuth2AuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository,
+            String authorizationBaseUri) {
+        this.delegate =
+                new DefaultOAuth2AuthorizationRequestResolver(
+                        clientRegistrationRepository, authorizationBaseUri);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request);
+        return customizeIfApple(request, authorizationRequest);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(
+            HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest authorizationRequest =
+                delegate.resolve(request, clientRegistrationId);
+        if (authorizationRequest == null) {
+            return null;
+        }
+        return "apple".equals(clientRegistrationId)
+                ? OAuth2AuthorizationRequest.from(authorizationRequest)
+                        .additionalParameters(params -> params.put("response_mode", "form_post"))
+                        .build()
+                : authorizationRequest;
+    }
+
+    public void setAuthorizationRequestCustomizer(
+            java.util.function.Consumer<OAuth2AuthorizationRequest.Builder>
+                    authorizationRequestCustomizer) {
+        delegate.setAuthorizationRequestCustomizer(authorizationRequestCustomizer);
+    }
+
+    private OAuth2AuthorizationRequest customizeIfApple(
+            HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {
+        if (authorizationRequest == null) {
+            return null;
+        }
+        String requestUri = request.getRequestURI();
+        if (requestUri != null && requestUri.endsWith("/apple")) {
+            return OAuth2AuthorizationRequest.from(authorizationRequest)
+                    .additionalParameters(params -> params.put("response_mode", "form_post"))
+                    .build();
+        }
+        return authorizationRequest;
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #381 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
email/name scope를 요청하면 Apple 인가 요청에 response_mode=form_post 필요하여 추가해두었습니다. 

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- Apple 인가 요청(= authorization request 생성 시점)에 response_mode=form_post를 추가하도록 AuthorizationRequestResolver Apple용으로 만들어서 적용하였습니다.
-

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
