### PR TITLE
[fix/#384] Apple Login invalid_request 오류 해결

### DIFF
--- a/clokey-api/src/main/java/org/clokey/global/security/AppleAwareOAuth2AuthorizationRequestResolver.java
+++ b/clokey-api/src/main/java/org/clokey/global/security/AppleAwareOAuth2AuthorizationRequestResolver.java
@@ -62,7 +62,8 @@ public class AppleAwareOAuth2AuthorizationRequestResolver
     private OAuth2AuthorizationRequest enforceAppleResponseMode(
             OAuth2AuthorizationRequest authorizationRequest) {
         String authorizationRequestUri =
-                UriComponentsBuilder.fromUriString(authorizationRequest.getAuthorizationRequestUri())
+                UriComponentsBuilder.fromUriString(
+                                authorizationRequest.getAuthorizationRequestUri())
                         .replaceQueryParam("response_mode", "form_post")
                         .build(true)
                         .toUriString();

--- a/clokey-api/src/main/java/org/clokey/global/security/AppleAwareOAuth2AuthorizationRequestResolver.java
+++ b/clokey-api/src/main/java/org/clokey/global/security/AppleAwareOAuth2AuthorizationRequestResolver.java
@@ -6,6 +6,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RequiredArgsConstructor
 public class AppleAwareOAuth2AuthorizationRequestResolver
@@ -36,9 +37,7 @@ public class AppleAwareOAuth2AuthorizationRequestResolver
             return null;
         }
         return "apple".equals(clientRegistrationId)
-                ? OAuth2AuthorizationRequest.from(authorizationRequest)
-                        .additionalParameters(params -> params.put("response_mode", "form_post"))
-                        .build()
+                ? enforceAppleResponseMode(authorizationRequest)
                 : authorizationRequest;
     }
 
@@ -55,10 +54,22 @@ public class AppleAwareOAuth2AuthorizationRequestResolver
         }
         String requestUri = request.getRequestURI();
         if (requestUri != null && requestUri.endsWith("/apple")) {
-            return OAuth2AuthorizationRequest.from(authorizationRequest)
-                    .additionalParameters(params -> params.put("response_mode", "form_post"))
-                    .build();
+            return enforceAppleResponseMode(authorizationRequest);
         }
         return authorizationRequest;
+    }
+
+    private OAuth2AuthorizationRequest enforceAppleResponseMode(
+            OAuth2AuthorizationRequest authorizationRequest) {
+        String authorizationRequestUri =
+                UriComponentsBuilder.fromUriString(authorizationRequest.getAuthorizationRequestUri())
+                        .replaceQueryParam("response_mode", "form_post")
+                        .build(true)
+                        .toUriString();
+
+        return OAuth2AuthorizationRequest.from(authorizationRequest)
+                .additionalParameters(params -> params.put("response_mode", "form_post"))
+                .authorizationRequestUri(authorizationRequestUri)
+                .build();
     }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #384 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
Apple로 리다이렉트되는 URL에 response_mode=form_post 적용

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- Apple 전용 resolver에서 인가 요청을 만들 때 additionalParameters에 response_mode=form_post를 넣고 최종 authorizationRequestUri 자체도 response_mode=form_post가 포함되도록 수정하였습니다.
-

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
