### PR TITLE
[fix/#387] Apple Login URI form_post 누락 문제 해결

### DIFF
--- a/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
+++ b/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
@@ -13,7 +13,6 @@ import org.clokey.helper.SpringEnvironmentHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -44,7 +43,6 @@ public class SecurityConfig {
     private final SpringEnvironmentHelper springEnvironmentHelper;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OidcLoginSuccessHandler oidcLoginSuccessHandler;
-    private final ApplicationContext applicationContext;
 
     @Autowired(required = false)
     private ClientRegistrationRepository clientRegistrationRepository;
@@ -101,7 +99,11 @@ public class SecurityConfig {
     @Order(2)
     @Profile({"local", "dev", "prod"})
     public SecurityFilterChain apiFilterChain(
-            HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+            HttpSecurity http,
+            JwtAuthenticationFilter jwtAuthenticationFilter,
+            @Autowired(required = false)
+                    OAuth2AuthorizationRequestResolver authorizationRequestResolver)
+            throws Exception {
         defaultFilterChain(http);
 
         http.authorizeHttpRequests(
@@ -118,18 +120,11 @@ public class SecurityConfig {
                                                     userInfo.oidcUserService(
                                                             customOAuth2UserService))
                                     .successHandler(oidcLoginSuccessHandler);
-                            if (clientRegistrationRepository != null) {
-                                try {
-                                    OAuth2AuthorizationRequestResolver resolver =
-                                            applicationContext.getBean(
-                                                    OAuth2AuthorizationRequestResolver.class);
-                                    oauth2.authorizationEndpoint(
-                                            authorization ->
-                                                    authorization.authorizationRequestResolver(
-                                                            resolver));
-                                } catch (Exception e) {
-                                    // Resolver bean이 없으면 기본 resolver 사용
-                                }
+                            if (authorizationRequestResolver != null) {
+                                oauth2.authorizationEndpoint(
+                                        authorization ->
+                                                authorization.authorizationRequestResolver(
+                                                        authorizationRequestResolver));
                             }
                         })
                 .addFilterBefore(


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #387 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
Apple Login URI form_post 누락 문제 해결

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
### 의존성 주입 구조 변경:
- 기존 applicationContext.getBean()을 통한 런타임 빈 조구 방식에서, SecurityConfig의 필터 체인 생성 시점에 OAuth2AuthorizationRequestResolver를 직접 주입받도록 변경했습니다.

### 설정 신뢰도 향상:
- @Autowired(required = false)를 활용하여 커스텀 리졸버가 존재할 경우에만 authorizationEndpoint에 명시적으로 등록되도록 보장했습니다.


## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
