### PR TITLE
[fix/#390] OAuth2 resolver 관련 문제 해결

### DIFF
--- a/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
+++ b/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
@@ -159,7 +159,6 @@ public class SecurityConfig {
     }
 
     @Bean
-    @ConditionalOnBean(ClientRegistrationRepository.class)
     public OAuth2AuthorizationRequestResolver oauth2AuthorizationRequestResolver() {
         if (clientRegistrationRepository == null) {
             throw new IllegalStateException("ClientRegistrationRepository is required for OAuth2");

--- a/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
+++ b/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
@@ -12,7 +12,6 @@ import org.clokey.global.security.JwtAuthenticationFilter;
 import org.clokey.helper.SpringEnvironmentHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -101,8 +100,7 @@ public class SecurityConfig {
     public SecurityFilterChain apiFilterChain(
             HttpSecurity http,
             JwtAuthenticationFilter jwtAuthenticationFilter,
-            @Autowired(required = false)
-                    OAuth2AuthorizationRequestResolver authorizationRequestResolver)
+            OAuth2AuthorizationRequestResolver authorizationRequestResolver)
             throws Exception {
         defaultFilterChain(http);
 
@@ -160,14 +158,13 @@ public class SecurityConfig {
 
     @Bean
     public OAuth2AuthorizationRequestResolver oauth2AuthorizationRequestResolver() {
-        if (clientRegistrationRepository == null) {
-            throw new IllegalStateException("ClientRegistrationRepository is required for OAuth2");
-        }
         AppleAwareOAuth2AuthorizationRequestResolver resolver =
                 new AppleAwareOAuth2AuthorizationRequestResolver(
                         clientRegistrationRepository, "/oauth2/authorization");
+
         resolver.setAuthorizationRequestCustomizer(
                 OAuth2AuthorizationRequestCustomizers.withPkce());
+
         return resolver;
     }
 }

--- a/clokey-api/src/main/resources/application-local.yml
+++ b/clokey-api/src/main/resources/application-local.yml
@@ -107,6 +107,7 @@ logging:
   level:
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
+    org.springframework.security: DEBUG
 
 firebase:
   credentials-path: ${FIREBASE_CREDENTIALS_PATH}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #390 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
조건부 빈 등록으로 인해 resolver가 적용되지 않을 수 있는 구조를 개선

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- @ConditionalOnBean 제거
- required=false 제거
- OAuth2AuthorizationRequestResolver를 필수 빈으로 변경

기존 조건부 빈 등록 구조로 인해 커스텀 Resolver가 적용되지 않고
기본 Resolver로 fallback 될 수 있는 구조를 개선하였습니다.

Apple 로그인 시 response_mode=form_post가 항상 적용될 수 있도록 하였습니다. 

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
