### PR TITLE
[fix/#393] OAuth2 CORS 문제 해결 및 swagger 접근 정책 보완

### DIFF
--- a/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
+++ b/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
@@ -10,7 +10,6 @@ import org.clokey.domain.auth.service.JwtTokenService;
 import org.clokey.global.security.AppleAwareOAuth2AuthorizationRequestResolver;
 import org.clokey.global.security.JwtAuthenticationFilter;
 import org.clokey.helper.SpringEnvironmentHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,9 +42,6 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OidcLoginSuccessHandler oidcLoginSuccessHandler;
 
-    @Autowired(required = false)
-    private ClientRegistrationRepository clientRegistrationRepository;
-
     @Value("${swagger.username:default}")
     private String swaggerUsername;
 
@@ -58,7 +54,8 @@ public class SecurityConfig {
                 .cors(withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(
-                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                        session ->
+                                session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
     }
 
     @Bean
@@ -85,10 +82,7 @@ public class SecurityConfig {
 
         http.securityMatcher("/swagger-ui/**", "/v3/api-docs/**").httpBasic(withDefaults());
 
-        http.authorizeHttpRequests(
-                (springEnvironmentHelper.isDevProfile())
-                        ? authorize -> authorize.anyRequest().authenticated()
-                        : authorize -> authorize.anyRequest().permitAll());
+        http.authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated());
 
         return http.build();
     }
@@ -107,7 +101,11 @@ public class SecurityConfig {
         http.authorizeHttpRequests(
                         auth ->
                                 auth.requestMatchers(
-                                                "/public/**", "/swagger-ui/**", "/v3/api-docs/**")
+                                                "/public/**",
+                                                "/swagger-ui/**",
+                                                "/v3/api-docs/**",
+                                                "/oauth2/**",
+                                                "/login/oauth2/**")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())
@@ -118,12 +116,10 @@ public class SecurityConfig {
                                                     userInfo.oidcUserService(
                                                             customOAuth2UserService))
                                     .successHandler(oidcLoginSuccessHandler);
-                            if (authorizationRequestResolver != null) {
-                                oauth2.authorizationEndpoint(
-                                        authorization ->
-                                                authorization.authorizationRequestResolver(
-                                                        authorizationRequestResolver));
-                            }
+                            oauth2.authorizationEndpoint(
+                                    a ->
+                                            a.authorizationRequestResolver(
+                                                    authorizationRequestResolver));
                         })
                 .addFilterBefore(
                         jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
@@ -134,19 +130,24 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-
         configuration.setAllowedOriginPatterns(
                 List.of(
                         "http://localhost:3000",
                         "https://dev.clokey.store",
                         "https://prod.clokey.store"));
-
         configuration.setAllowedMethods(
                 List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
 
+        CorsConfiguration appleCallbackConfiguration = new CorsConfiguration();
+        appleCallbackConfiguration.setAllowedOriginPatterns(List.of("https://appleid.apple.com"));
+        appleCallbackConfiguration.setAllowedMethods(List.of("POST", "OPTIONS"));
+        appleCallbackConfiguration.setAllowedHeaders(List.of("*"));
+        appleCallbackConfiguration.setAllowCredentials(true);
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/login/oauth2/code/**", appleCallbackConfiguration);
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
@@ -157,14 +158,15 @@ public class SecurityConfig {
     }
 
     @Bean
-    public OAuth2AuthorizationRequestResolver oauth2AuthorizationRequestResolver() {
+    @Profile({"local", "dev", "prod"})
+    public OAuth2AuthorizationRequestResolver oauth2AuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository) {
         AppleAwareOAuth2AuthorizationRequestResolver resolver =
                 new AppleAwareOAuth2AuthorizationRequestResolver(
                         clientRegistrationRepository, "/oauth2/authorization");
 
         resolver.setAuthorizationRequestCustomizer(
                 OAuth2AuthorizationRequestCustomizers.withPkce());
-
         return resolver;
     }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #393 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
Apple OIDC 로그인 과정에서 POST callback으로 인한 CORS 문제 해결
Swagger 접근 정책을 보완 -> 보안 강화 

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
### Apple 콜백 CORS 처리
- Apple form_post 콜백 경로(`/login/oauth2/code/**`)에 대해
  별도 CORS 설정 추가
- 허용 Origin: https://appleid.apple.com
- 허용 Method: POST, OPTIONS
- Invalid CORS request 문제 해결

### Swagger 보안 강화
- swaggerFilterChain에서 anyRequest().authenticated()로 통일
- dev/local/prod 모든 환경에서 Swagger는 BasicAuth 인증 필요
- 프로덕션에서 Swagger가 공개되는 보안 이슈 방지

### 세션 정책 조정
- SessionCreationPolicy를 IF_REQUIRED로 변경하여 OAuth2 state/nonce 검증이 정상 동작하도록 보완

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
