### PR TITLE
[fix/#399] Swagger 로그인 리다이렉트 문제 수정 및 OpenAPI 인증 설정 정리 

### DIFF
--- a/.github/workflows/prod-openapi.yml
+++ b/.github/workflows/prod-openapi.yml
@@ -16,11 +16,13 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     env:
       CODIVEAPI_BRANCH: main
       TARGET_PATH: Sources/CodiveAPI/openapi.yaml
+      SWAGGER_USERNAME: ${{ secrets.SWAGGER_USERNAME }}
+      SWAGGER_PASSWORD: ${{ secrets.SWAGGER_PASSWORD }}
 
     steps:
       - name: Checkout backend repo (for context only)
@@ -36,7 +38,9 @@ jobs:
           echo "Waiting for production OpenAPI to be ready..."
 
           for i in {1..30}; do
-            if curl -fsS --connect-timeout 5 "$PROD_OPENAPI_URL" > /dev/null; then
+            if curl -fsS --connect-timeout 5 \
+              -u "$SWAGGER_USERNAME:$SWAGGER_PASSWORD" \
+              "$PROD_OPENAPI_URL" > /dev/null; then
               echo "Server is ready."
               exit 0
             fi
@@ -55,6 +59,7 @@ jobs:
           set -euo pipefail
           echo "Fetching OpenAPI from: $PROD_OPENAPI_URL"
           curl -fsSL --retry 5 --retry-delay 2 --connect-timeout 10 --max-time 30 \
+            -u "$SWAGGER_USERNAME:$SWAGGER_PASSWORD" \
             "$PROD_OPENAPI_URL" -o openapi.json
           test -s openapi.json
           head -c 1 openapi.json | grep -q '{'

--- a/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
+++ b/clokey-api/src/main/java/org/clokey/global/config/security/SecurityConfig.java
@@ -9,24 +9,18 @@ import org.clokey.domain.auth.service.CustomOAuth2UserService;
 import org.clokey.domain.auth.service.JwtTokenService;
 import org.clokey.global.security.AppleAwareOAuth2AuthorizationRequestResolver;
 import org.clokey.global.security.JwtAuthenticationFilter;
-import org.clokey.helper.SpringEnvironmentHelper;
-import org.springframework.beans.factory.annotation.Value;
+import org.clokey.global.security.SwaggerBasicAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
-import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestCustomizers;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -38,15 +32,12 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final SpringEnvironmentHelper springEnvironmentHelper;
+    private static final String[] SWAGGER_PATHS = {
+        "/swagger-ui", "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs", "/v3/api-docs/**"
+    };
+
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OidcLoginSuccessHandler oidcLoginSuccessHandler;
-
-    @Value("${swagger.username:default}")
-    private String swaggerUsername;
-
-    @Value("${swagger.password:default}")
-    private String swaggerPassword;
 
     private void defaultFilterChain(HttpSecurity http) throws Exception {
         http.httpBasic(AbstractHttpConfigurer::disable)
@@ -59,53 +50,26 @@ public class SecurityConfig {
     }
 
     @Bean
-    public InMemoryUserDetailsManager inMemoryUserDetailsManager() {
-        UserDetails user =
-                User.withUsername(swaggerUsername)
-                        .password(passwordEncoder().encode(swaggerPassword))
-                        .roles("SWAGGER")
-                        .build();
-
-        return new InMemoryUserDetailsManager(user);
-    }
-
-    @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
-    @Order(1)
-    @Profile({"dev", "local", "prod"})
-    public SecurityFilterChain swaggerFilterChain(HttpSecurity http) throws Exception {
-        defaultFilterChain(http);
-
-        http.securityMatcher("/swagger-ui/**", "/v3/api-docs/**").httpBasic(withDefaults());
-
-        http.authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated());
-
-        return http.build();
-    }
-
-    /** 인증 없이 제공하고 싶은 API는 /public 으로 시작해야 합니다. */
-    @Bean
-    @Order(2)
-    @Profile({"local", "dev", "prod"})
     public SecurityFilterChain apiFilterChain(
             HttpSecurity http,
             JwtAuthenticationFilter jwtAuthenticationFilter,
-            OAuth2AuthorizationRequestResolver authorizationRequestResolver)
+            OAuth2AuthorizationRequestResolver authorizationRequestResolver,
+            SwaggerBasicAuthenticationFilter swaggerBasicAuthenticationFilter)
             throws Exception {
         defaultFilterChain(http);
 
         http.authorizeHttpRequests(
                         auth ->
-                                auth.requestMatchers(
-                                                "/public/**",
-                                                "/swagger-ui/**",
-                                                "/v3/api-docs/**",
-                                                "/oauth2/**",
-                                                "/login/oauth2/**")
+                                auth.requestMatchers("/public/**")
+                                        .permitAll()
+                                        .requestMatchers("/oauth2/**", "/login/oauth2/**")
+                                        .permitAll()
+                                        .requestMatchers(SWAGGER_PATHS)
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())
@@ -121,6 +85,9 @@ public class SecurityConfig {
                                             a.authorizationRequestResolver(
                                                     authorizationRequestResolver));
                         })
+                .addFilterBefore(
+                        swaggerBasicAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(
                         jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
@@ -158,7 +125,6 @@ public class SecurityConfig {
     }
 
     @Bean
-    @Profile({"local", "dev", "prod"})
     public OAuth2AuthorizationRequestResolver oauth2AuthorizationRequestResolver(
             ClientRegistrationRepository clientRegistrationRepository) {
         AppleAwareOAuth2AuthorizationRequestResolver resolver =

--- a/clokey-api/src/main/java/org/clokey/global/security/SwaggerBasicAuthenticationFilter.java
+++ b/clokey-api/src/main/java/org/clokey/global/security/SwaggerBasicAuthenticationFilter.java
@@ -1,0 +1,90 @@
+package org.clokey.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class SwaggerBasicAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String[] SWAGGER_PATHS = {
+        "/swagger-ui", "/swagger-ui/", "/swagger-ui.html", "/v3/api-docs"
+    };
+
+    @Value("${swagger.username:default}")
+    private String swaggerUsername;
+
+    @Value("${swagger.password:default}")
+    private String swaggerPassword;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+
+        for (String swaggerPath : SWAGGER_PATHS) {
+            if (uri.equals(swaggerPath) || uri.startsWith(swaggerPath + "/")) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String authorization = request.getHeader("Authorization");
+
+        if (authorization == null || !authorization.startsWith("Basic ")) {
+            writeUnauthorized(response);
+            return;
+        }
+
+        String[] credentials = decodeCredentials(authorization.substring(6));
+        if (credentials == null) {
+            writeUnauthorized(response);
+            return;
+        }
+
+        if (!swaggerUsername.equals(credentials[0]) || !swaggerPassword.equals(credentials[1])) {
+            writeUnauthorized(response);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String[] decodeCredentials(String encodedCredentials) {
+        try {
+            String decoded =
+                    new String(
+                            Base64.getDecoder().decode(encodedCredentials), StandardCharsets.UTF_8);
+            int separatorIndex = decoded.indexOf(':');
+            if (separatorIndex < 0) {
+                return null;
+            }
+
+            return new String[] {
+                decoded.substring(0, separatorIndex), decoded.substring(separatorIndex + 1)
+            };
+        } catch (IllegalArgumentException exception) {
+            return null;
+        }
+    }
+
+    private void writeUnauthorized(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setHeader("WWW-Authenticate", "Basic realm=\"Swagger\"");
+        response.getWriter().flush();
+    }
+}

--- a/clokey-api/src/main/resources/application-dev.yml
+++ b/clokey-api/src/main/resources/application-dev.yml
@@ -98,7 +98,7 @@ swagger:
   username: ${SWAGGER_USERNAME}
   password: ${SWAGGER_PASSWORD}
 
-spring-doc:
+springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
   swagger-ui:

--- a/clokey-api/src/main/resources/application-local.yml
+++ b/clokey-api/src/main/resources/application-local.yml
@@ -94,14 +94,14 @@ external:
     style-inference-path: ${STYLE_INFERENCE_PATH}
     cloth-detect-path: ${CLOTH_DETECT_PATH}
 
-spring-doc:
+springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
   swagger-ui:
     tags-sorter: alpha
-    operations-sorter : method
+    operations-sorter: method
     path: /swagger-ui
-    doc-expansion : none
+    doc-expansion: none
 
 logging:
   level:

--- a/clokey-api/src/main/resources/application-prod.yml
+++ b/clokey-api/src/main/resources/application-prod.yml
@@ -96,6 +96,20 @@ external:
     cloth-inference-path: ${CLOTH_INFERENCE_PATH}
     style-inference-path: ${STYLE_INFERENCE_PATH}
     cloth-detect-path: ${CLOTH_DETECT_PATH}
+
+swagger:
+  username: ${SWAGGER_USERNAME}
+  password: ${SWAGGER_PASSWORD}
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    tags-sorter: alpha
+    operations-sorter : method
+    path: /swagger-ui
+    doc-expansion : none
+
 app:
   oauth:
     redirect-scheme: codive

--- a/clokey-api/src/test/java/org/clokey/ClokeyApiApplicationTests.java
+++ b/clokey-api/src/test/java/org/clokey/ClokeyApiApplicationTests.java
@@ -3,6 +3,7 @@ package org.clokey;
 import com.google.firebase.messaging.FirebaseMessaging;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -11,6 +12,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 class ClokeyApiApplicationTests {
 
     @MockitoBean private FirebaseMessaging mockFirebaseMessaging;
+    @MockitoBean private ClientRegistrationRepository clientRegistrationRepository;
 
     @Test
     void contextLoads() {}

--- a/clokey-api/src/test/java/org/clokey/IntegrationTest.java
+++ b/clokey-api/src/test/java/org/clokey/IntegrationTest.java
@@ -4,6 +4,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -13,6 +14,7 @@ public abstract class IntegrationTest {
 
     @Autowired protected DatabaseCleaner databaseCleaner;
     @MockitoBean private FirebaseMessaging mockFirebaseMessaging;
+    @MockitoBean private ClientRegistrationRepository clientRegistrationRepository;
 
     @BeforeEach
     void setUp() {

--- a/clokey-api/src/test/java/org/clokey/global/config/security/SwaggerSecurityIntegrationTest.java
+++ b/clokey-api/src/test/java/org/clokey/global/config/security/SwaggerSecurityIntegrationTest.java
@@ -1,0 +1,65 @@
+package org.clokey.global.config.security;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"test", "local"})
+@TestPropertySource(
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password=",
+            "spring.flyway.enabled=false",
+            "spring.jpa.hibernate.ddl-auto=none",
+            "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+            "jwt.access-token-secret=test-access-secret-test-access-secret",
+            "jwt.refresh-token-secret=test-refresh-secret-test-refresh-secret",
+            "jwt.access-token-expiration-time=3600000",
+            "jwt.refresh-token-expiration-time=1209600000",
+            "jwt.issuer=test-issuer",
+            "spring.security.oauth2.client.registration.kakao.client-id=test",
+            "spring.security.oauth2.client.registration.kakao.client-secret=test",
+            "spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost/login/oauth2/code/kakao",
+            "spring.security.oauth2.client.registration.apple.client-id=test",
+            "spring.security.oauth2.client.registration.apple.client-secret=test",
+            "spring.security.oauth2.client.registration.apple.redirect-uri=http://localhost/login/oauth2/code/apple",
+            "external.api.ai-server-ip=http://localhost",
+            "external.api.cloth-inference-path=/cloth",
+            "external.api.style-inference-path=/style",
+            "external.api.cloth-detect-path=/detect",
+            "firebase.credentials-path=dummy"
+        })
+class SwaggerSecurityIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockitoBean private FirebaseMessaging mockFirebaseMessaging;
+
+    @Test
+    void swaggerUiIndexWithoutCredentialsDoesNotRedirectToLogin() throws Exception {
+        mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().string("WWW-Authenticate", containsString("Basic")));
+    }
+
+    @Test
+    void swaggerConfigWithoutCredentialsDoesNotRedirectToLogin() throws Exception {
+        mockMvc.perform(get("/v3/api-docs/swagger-config"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().string("WWW-Authenticate", containsString("Basic")));
+    }
+}

--- a/clokey-api/src/test/resources/application-test.yml
+++ b/clokey-api/src/test/resources/application-test.yml
@@ -31,3 +31,7 @@ firebase:
   token-uri: dummy
   auth-provider-x509-cert-url: dummy
   client-x509-cert-url: dummy
+
+swagger:
+  username: swagger
+  password: swagger


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #399 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
Swagger 접속 시 /login으로 리다이렉트되던 문제를 수정했습니다. 
또한 prod-openapi.yml을 수정했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->                                                                                                             
- Swagger/OpenAPI 경로에 대해 Basic Auth 기반 접근 제어가 동작하도록 보안 설정을 정리했습니다.
- springdoc 설정 키를 환경별 설정 파일에 맞게 수정해 Swagger 경로 설정이 정상 적용되도록 했습니다.                                                                                
- prod-openapi.yml에서 Swagger 인증 환경변수명을 SWAGGER_USERNAME, SWAGGER_PASSWORD로 통일했습니다.                                                                               
- Swagger/OpenAPI 경로가 로그인 페이지로 이동하지 않는지 확인하는 테스트 코드를 추가했습니다.  

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
