### PR TITLE
[fix/#402] 옷 목록 조회 API에서 isTodayCoordinateCloth 필드 추가

### DIFF
--- a/clokey-api/src/main/java/org/clokey/domain/cloth/dto/response/ClothListResponse.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/dto/response/ClothListResponse.java
@@ -8,4 +8,22 @@ public record ClothListResponse(
         @Schema(description = "옷 브랜드 이름", example = "나이키") String brand,
         @Schema(description = "옷 이름", example = "파란색 후드") String name,
         @Schema(description = "상위 카테고리 이름", example = "상의") String parentCategory,
-        @Schema(description = "하위 카테고리 이름", example = "후드티") String category) {}
+        @Schema(description = "하위 카테고리 이름", example = "후드티") String category,
+        @Schema(description = "오늘의 코디에 포함된 옷인지 여부", example = "true")
+                boolean isTodayCoordinateCloth) {
+
+    public ClothListResponse(
+            Long clothId,
+            String ImageUrl,
+            String brand,
+            String name,
+            String parentCategory,
+            String category) {
+        this(clothId, ImageUrl, brand, name, parentCategory, category, false);
+    }
+
+    public ClothListResponse withTodayCoordinateCloth(boolean isTodayCoordinateCloth) {
+        return new ClothListResponse(
+                clothId, ImageUrl, brand, name, parentCategory, category, isTodayCoordinateCloth);
+    }
+}

--- a/clokey-api/src/main/java/org/clokey/domain/cloth/service/ClothServiceImpl.java
+++ b/clokey-api/src/main/java/org/clokey/domain/cloth/service/ClothServiceImpl.java
@@ -1,5 +1,7 @@
 package org.clokey.domain.cloth.service;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -17,6 +19,7 @@ import org.clokey.domain.cloth.dto.response.*;
 import org.clokey.domain.cloth.exception.ClothErrorCode;
 import org.clokey.domain.cloth.repository.ClothRepository;
 import org.clokey.domain.coordinate.repository.CoordinateClothRepository;
+import org.clokey.domain.coordinate.repository.CoordinateRepository;
 import org.clokey.domain.history.repository.HistoryClothTagRepository;
 import org.clokey.domain.image.event.ImageDeleteEvent;
 import org.clokey.domain.search.event.ClothDeleteEvent;
@@ -28,7 +31,9 @@ import org.clokey.member.entity.Member;
 import org.clokey.response.SliceResponse;
 import org.clokey.util.S3Util;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,11 +41,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ClothServiceImpl implements ClothService {
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
     private final MemberUtil memberUtil;
 
     private final ClothRepository clothRepository;
     private final CategoryRepository categoryRepository;
     private final HistoryClothTagRepository historyClothTagRepository;
+    private final CoordinateRepository coordinateRepository;
 
     private final ApplicationEventPublisher eventPublisher;
     private final CoordinateClothRepository coordinateClothRepository;
@@ -115,7 +123,27 @@ public class ClothServiceImpl implements ClothService {
                 clothRepository.findAllMemberClothesByCategoriesAndSeasons(
                         lastClothId, size, direction, categoryIds, currentMember.getId(), seasons);
 
-        return SliceResponse.from(result);
+        Set<Long> todayCoordinateClothIds =
+                coordinateRepository
+                        .findDailyCoordinateByDateAndMemberId(
+                                LocalDate.now(KST), currentMember.getId())
+                        .map(
+                                coordinate ->
+                                        coordinate.getCoordinateClothes().stream()
+                                                .map(cc -> cc.getCloth().getId())
+                                                .collect(Collectors.toSet()))
+                        .orElse(Set.of());
+
+        List<ClothListResponse> content =
+                result.getContent().stream()
+                        .map(
+                                cloth ->
+                                        cloth.withTodayCoordinateCloth(
+                                                todayCoordinateClothIds.contains(cloth.clothId())))
+                        .toList();
+
+        return SliceResponse.from(
+                new SliceImpl<>(content, PageRequest.of(0, size), result.hasNext()));
     }
 
     @Override

--- a/clokey-api/src/test/java/org/clokey/domain/cloth/controller/ClothControllerTest.java
+++ b/clokey-api/src/test/java/org/clokey/domain/cloth/controller/ClothControllerTest.java
@@ -376,14 +376,16 @@ class ClothControllerTest {
                                     "testBrand1",
                                     "testName1",
                                     "testParentCategory1",
-                                    "testCategory1"),
+                                    "testCategory1",
+                                    true),
                             new ClothListResponse(
                                     2L,
                                     "testImageUrl2",
                                     "testBrand2",
                                     "testName2",
                                     "testParentCategory2",
-                                    "testCategory2"));
+                                    "testCategory2",
+                                    false));
 
             given(clothService.getClothes(null, 2, SortDirection.ASC, 1L, List.of(Season.SPRING)))
                     .willReturn(new SliceResponse<>(clothListResponses, true));
@@ -401,7 +403,9 @@ class ClothControllerTest {
                     .andExpect(jsonPath("$.isSuccess").value(true))
                     .andExpect(jsonPath("$.code").value("COMMON200"))
                     .andExpect(jsonPath("$.result.content[0].clothId").value(1))
+                    .andExpect(jsonPath("$.result.content[0].isTodayCoordinateCloth").value(true))
                     .andExpect(jsonPath("$.result.content[1].clothId").value(2))
+                    .andExpect(jsonPath("$.result.content[1].isTodayCoordinateCloth").value(false))
                     .andExpect(jsonPath("$.result.isLast").value(true));
         }
 


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #402 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
옷 목록 조회 api에서 조회된 옷들 중 오늘의 코디에 해당하는 옷인지에 대한 여부를 반환하는 필드가 필요하여 isTodayCoordinateCloth (boolean값) 필드 추가하였습니다. 

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 
-

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
